### PR TITLE
tracker softdirty: remove access data on removing a pid

### DIFF
--- a/pkg/memtier/tracker_softdirty.go
+++ b/pkg/memtier/tracker_softdirty.go
@@ -151,6 +151,7 @@ func (t *TrackerSoftDirty) RemovePids(pids []int) {
 
 func (t *TrackerSoftDirty) removePid(pid int) {
 	delete(t.regions, pid)
+	delete(t.accesses, pid)
 }
 
 func (t *TrackerSoftDirty) ResetCounters() {


### PR DESCRIPTION
This change makes the removePid logic similar in both softdirty and idlepage trackers.