### PR TITLE
sample-configs: add example yaml for "filter" pidwatcher from cgroups

### DIFF
--- a/pkg/memtier/pidwatcher_cgroups.go
+++ b/pkg/memtier/pidwatcher_cgroups.go
@@ -59,6 +59,9 @@ func (w *PidWatcherCgroups) SetConfigJson(configJson string) error {
 	if config.IntervalMs == 0 {
 		config.IntervalMs = 5000
 	}
+	if len(config.Cgroups) == 0 {
+		log.Warnf("PidWatcherCgroups: cgroups config is missing\n")
+	}
 	w.config = config
 	return nil
 }

--- a/sample-configs/memtierd-age-idlepage-trackonly.yaml
+++ b/sample-configs/memtierd-age-idlepage-trackonly.yaml
@@ -29,6 +29,7 @@ policy:
     # Found processes can be filtered using the "filter" pidwatcher.
     # The source pidwatcher can be "cgroup" or "proc", for instance,
     # and processes can be selected based on /proc/pid/exe filepath:
+    # when the source pidwatcher is "proc",
     # pidwatcher:
     #   name: filter
     #   config: |
@@ -36,6 +37,21 @@ policy:
     #       name: proc
     #       config: |
     #         intervalms: 10000
+    #     filters:
+    #       - procexeregexp: ".*/meme"
+    #
+    # when the source pidwatcher is "cgroups",
+    # pidwatcher:
+    #   name: filter
+    #   config: |
+    #     source:
+    #       name: cgroups
+    #       config: |
+    #         intervalms: 10000
+    #         cgroups:
+    #           - /sys/fs/cgroup/foobar0
+    #           - /sys/fs/cgroup/foobar1
+    #           ...
     #     filters:
     #       - procexeregexp: ".*/meme"
 


### PR DESCRIPTION
Also raise a warning if cgroups config is missing for PidWatcherCgroups

examples:
root@vm> nohup sh -c 'socat tcp4-listen:5555,fork,reuseaddr - | memtierd -config memtierd.yaml -debug' > memtierd.output.txt 2>&1 & sleep 2; cat memtierd.output.txt
**WARN: memtier PidWatcherCgroups: cgroups config is missing**
memtierd> DEBUG: memtier TrackerSoftDirty: online