### PR TITLE
build: never build meme with race detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ bin/%: .static.%.$(STATIC)
 	$(Q)bin=$(notdir $@); src=./cmd/$$bin; \
 	echo "Building $$([ -n "$(STATIC)" ] && echo 'static ')$@ (version $(BUILD_VERSION), build $(BUILD_BUILDID))..."; \
 	mkdir -p bin && \
-	$(GO_BUILD) $(BUILD_TAGS) $(LDFLAGS) $(GCFLAGS) $(RACEFLAGS) -o bin/ $$src
+	$(GO_BUILD) $(BUILD_TAGS) $(LDFLAGS) $(GCFLAGS) $(if $(filter bin/meme,$@),,$(RACEFLAGS)) -o bin/ $$src
 
 .static.%.$(STATIC):
 	$(Q)if [ ! -f "$@" ]; then \


### PR DESCRIPTION
Building meme with the -race flag changes memory consumption and access patterns of the process so that it will cause e2e tests to fail. This patch enables building everything simply with
    make RACE=1
and running e2e tests with memtierd race detection on.