### PR TITLE
pidwatcher cgroups: log a warning on bad paths

### DIFF
--- a/pkg/memtier/pidwatcher_cgroups.go
+++ b/pkg/memtier/pidwatcher_cgroups.go
@@ -233,7 +233,12 @@ func readPids(path string) ([]int, error) {
 	return pids, nil
 }
 
+var warnedOnBadPath map[string]bool
+
 func findFiles(root string, filename string) []string {
+	if warnedOnBadPath == nil {
+		warnedOnBadPath = map[string]bool{}
+	}
 	matchingFiles := []string{}
 	filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -244,6 +249,10 @@ func findFiles(root string, filename string) []string {
 		}
 		return nil
 	})
+	if len(matchingFiles) == 0 && !warnedOnBadPath[root] {
+		warnedOnBadPath[root] = true
+		log.Warnf("PidWatcherCgroups: invalid path %q\n", root)
+	}
 	return matchingFiles
 }
 

--- a/pkg/memtier/policy_ratio.go
+++ b/pkg/memtier/policy_ratio.go
@@ -485,7 +485,7 @@ func (p *PolicyRatio) loop() {
 				}
 			}
 		}
-		log.Debugf("Ratio loop %v moved lengh: %v\n", n, calcLen)
+		log.Debugf("Ratio loop %v moved length: %v\n", n, calcLen)
 
 		// When the RatioTargets field is missing or set as [-1], swap out the memory calculated above
 		// Otherwise, move the memory to the target numa nodes


### PR DESCRIPTION
Help detecting user errors by logging a warning if a directory in a cgroups pidwatcher configuration does not contain the cgroups.procs file. Do not log more than one warning on each bad directory path. This patch fixes a typo in the ratio policy debug print, too.