### PR TITLE
fix pageout waiting time and deleting cgroup dir for e2e tests

### DIFF
--- a/test/e2e/memtierd.test-suite/memtierd.source.sh
+++ b/test/e2e/memtierd.test-suite/memtierd.source.sh
@@ -110,7 +110,8 @@ memtierd-meme-start() {
 
 memtierd-meme-stop() {
     vm-command "killall -KILL meme"
-    if [[ -n "$MEME_CGROUP" ]]; then
+    sleep 2
+    if [[ -z "$MEME_PID" ]] && [[ -n "$MEME_CGROUP" ]]; then
         vm-command "sudo rmdir /sys/fs/cgroup/$MEME_CGROUP"
     fi
 }

--- a/test/e2e/memtierd.test-suite/policy-heat/n4c16/test00-swap-idlepage/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-heat/n4c16/test00-swap-idlepage/code.var.sh
@@ -73,7 +73,7 @@ grep " 7[0-9][0-9] " <<<"$COMMAND_OUTPUT" || {
 
 echo "stop meme, expect all memory to be paged out"
 vm-command "kill -STOP ${MEME_PID}"
-memtierd-match-pageout "1\.[0-2]" 5 6
+memtierd-match-pageout "1\.[0-2]" 5 1
 
 echo "continue meme, expect 300 MB to be swapped in by OS"
 vm-command "kill -CONT ${MEME_PID}"
@@ -85,7 +85,7 @@ grep " 7[0-9][0-9] " <<<"$COMMAND_OUTPUT" || {
 
 echo "stop meme again, verify that all memory gets paged out again"
 vm-command "kill -STOP ${MEME_PID}"
-memtierd-match-pageout "1\.[2-5]" 6 6
+memtierd-match-pageout "1\.[2-5]" 5 1
 
 memtierd-stop
 memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-heat/n4c16/test01-swap-softdirty/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-heat/n4c16/test01-swap-softdirty/code.var.sh
@@ -55,7 +55,7 @@ grep " 7[0-9][0-9] " <<<"$COMMAND_OUTPUT" || {
 
 echo "stop meme, expect all memory to be paged out"
 vm-command "kill -STOP ${MEME_PID}"
-memtierd-match-pageout "1\.[0-2]" 5 6
+memtierd-match-pageout "1\.[0-2]" 5 1
 
 echo "continue meme, expect 300 MB to be swapped in by OS"
 vm-command "kill -CONT ${MEME_PID}"
@@ -67,7 +67,7 @@ grep " 7[0-9][0-9] " <<<"$COMMAND_OUTPUT" || {
 
 echo "stop meme again, verify that all memory gets paged out again"
 vm-command "kill -STOP ${MEME_PID}"
-memtierd-match-pageout "1\.[2-5]" 6 6
+memtierd-match-pageout "1\.[2-5]" 5 1
 
 memtierd-stop
 memtierd-meme-stop


### PR DESCRIPTION
This PR fixes the following two issues:

**1. Failed to delete cgroup dir, add sleep time after killing meme and only try to delete cgroup dir when meme process is not found**
```bash
stop meme again, verify that all memory gets paged out again
root@vm> kill -STOP 5191
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
memtierd> stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.045261
memtierd> grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.335884
memtierd> 1.335884
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'q' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
memtierd> q
quit.
host> sleep 1
root@vm> killall -KILL memtierd; pkill -f 'socat tcp4-listen:5555'
memtierd: no process found
root@vm> killall -KILL meme
root@vm> sudo rmdir /sys/fs/cgroup/e2e-meme
**rmdir: failed to remove '/sys/fs/cgroup/e2e-meme': Device or resource busy**
host> scp -o StrictHostKeyChecking=No -o ControlMaster=auto -o ControlPath=/home/jing/vms/data/n4c16-ubuntu-22.04-containerd/ssh -o ControlPersist=30 ubuntu@172.17.0.2:memtierd*.output.txt "/home/jing/go/src/github.com/intel/memtierd/test/e2e/memtierd.test-suite/policy-heat/n4c16/test00-swap-idlepage/output/"
The VM, Kubernetes and cri-resmgr are left running. Next steps:
- Login VM:     ssh ubuntu@172.17.0.2
- Stop VM:      govm stop n4c16-ubuntu-22.04-containerd
- Delete VM:    govm delete n4c16-ubuntu-22.04-containerd
**Test verdict: FAIL**
```

**2. Resume the waiting rounds and timeout for pageout check before https://github.com/intel/memtierd/pull/54
```bash
stop meme again, verify that all memory gets paged out again
root@vm> kill -STOP 6531
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> DEBUG: memtier PolicyHeat: updating heatmap with 0 address ranges
grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

PAGEOUT[G]
1.019878
memtierd> DEBUG: memtier PolicyHeat: updating heatmap with 0 address ranges
grep PAGEOUT value matching 1\.[2-5] not found
host> sleep 6
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'stats -t process_madvise -f csv | awk -F, "{print \$6}"' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
stats -t process_madvise -f csv | awk -F, "{print \$6}"

**PAGEOUT[G]
1.019878
memtierd> grep PAGEOUT value matching 1\.[2-5] not found**

error: timeout: memtierd did not pageout expected amount of memory
host> scp -o StrictHostKeyChecking=No -o ControlMaster=auto -o ControlPath=/home/jing/vms/data/n4c16-ubuntu-22.04-containerd/ssh -o ControlPersist=30 ubuntu@172.17.0.2:memtierd*.output.txt "/home/jing/go/src/github.com/intel/memtierd/test/e2e/memtierd.test-suite/policy-heat/n4c16/test00-swap-idlepage/output/"
The VM, Kubernetes and cri-resmgr are left running. Next steps:
- Login VM:     ssh ubuntu@172.17.0.2
- Stop VM:      govm stop n4c16-ubuntu-22.04-containerd
- Delete VM:    govm delete n4c16-ubuntu-22.04-containerd
**Test verdict: FAIL**
```