### PR TITLE
Delay calling mover.Wait when using mover with *wait flag

### DIFF
--- a/pkg/memtier/prompt.go
+++ b/pkg/memtier/prompt.go
@@ -783,6 +783,7 @@ func (p *Prompt) cmdMover(args []string) CommandStatus {
 		p.mover.RemoveTask(*removeTask)
 	}
 	if *wait {
+		time.Sleep(100 * time.Millisecond)
 		p.output("mover wait received: %s\n", <-p.mover.Wait(thsPaused, thsAllDone))
 	}
 	return csOk

--- a/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
+++ b/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
@@ -71,9 +71,9 @@ mover_swap_conf=(
 )
 
 declare -A mover_swap_seconds=(
-    ["min0"]=4 ["max0"]=7
-    ["min2"]=2 ["max2"]=4
-    ["min1"]=2 ["max1"]=6
+    ["min0"]=4 ["max0"]=14
+    ["min2"]=2 ["max2"]=8
+    ["min1"]=2 ["max1"]=12
 )
 
 echo -e "\n=== scenario 1: test moving memories among numa nodes ===\n"


### PR DESCRIPTION
This PR fixes the issue that "mover -wait" might get called earlier than the mover starts handling new tasks.
In this case, "mover -wait" returns immediately as Paused as follows.
```bash
root@vm> offset=$(wc -l memtierd.output.txt | awk '{print $1+1}'); echo -e 'mover -config {"IntervalMs":10,"Bandwidth":5}\nswap -out -pids 40436 -mover\nmover -wait' | socat - tcp4:localhost:5555; sleep 1; tail -n+${offset} memtierd.output.txt
memtierd> memtierd> DEBUG: memtier Mover: online
memtierd> mover wait received: Paused
```
With the current PR, mover will first start handling new tasks, "swap -pid $PID -status" will not return anything until "mover -wait" returns "memtierd> mover wait received: AllDone". Thus, also increases the max waiting time for related e2e test cases because of the delay.