### PR TITLE
trackers: fix softdirty and idlepage sudden tracking stops

### DIFF
--- a/pkg/memtier/tracker_softdirty.go
+++ b/pkg/memtier/tracker_softdirty.go
@@ -121,19 +121,20 @@ func (t *TrackerSoftDirty) GetConfigJSON() string {
 }
 
 func (t *TrackerSoftDirty) addRanges(pid int) {
-	delete(t.regions, pid)
+	t.regions[pid] = []*AddrRanges{}
 	p := NewProcess(pid)
 	if ar, err := p.AddressRanges(); err == nil {
 		// filter out single-page address ranges
 		ar = ar.Filter(func(r AddrRange) bool { return r.Length() > 1 })
 		ar = ar.SplitLength(t.config.PagesInRegion)
 		for _, r := range ar.Flatten() {
-			if regions, ok := t.regions[pid]; ok {
-				t.regions[pid] = append(regions, r)
-			} else {
-				t.regions[pid] = []*AddrRanges{r}
-			}
+			t.regions[pid] = append(t.regions[pid], r)
 		}
+	} else {
+		delete(t.regions, pid)
+		t.mutex.Lock()
+		delete(t.accesses, pid)
+		t.mutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
If a process got completely swapped out, trackers got only an empty list of address ranges and treated this as a signal of the whole process having disappeared. As a result, they effectively stopped tracking the process. Change the behavior so that only an error in reading address ranges means that the processes has disappeared, and in that case, remove also tracking counters of that process. That is, GetCounters() will return data only on processes that are thought to be running.