### PR TITLE
e2e: always clean up meme cgroup if it was in use

### DIFF
--- a/test/e2e/memtierd.test-suite/memtierd.source.sh
+++ b/test/e2e/memtierd.test-suite/memtierd.source.sh
@@ -110,9 +110,8 @@ memtierd-meme-start() {
 
 memtierd-meme-stop() {
     vm-command "killall -KILL meme"
-    sleep 2
-    if [[ -z "$MEME_PID" ]] && [[ -n "$MEME_CGROUP" ]]; then
-        vm-command "sudo rmdir /sys/fs/cgroup/$MEME_CGROUP"
+    if [[ -n "$MEME_CGROUP" ]]; then
+        vm-command "sleep 1; rmdir /sys/fs/cgroup/$MEME_CGROUP || true"
     fi
 }
 


### PR DESCRIPTION
memtierd-meme-stop does not need to sleep unless it is removing the meme cgroup. The cgroup should be removed regardless of MEME_PID environment variable, but if removing it fails, it is not an error of stopping meme. In that case there might be something else running in the cgroup, and we will let them run. Memes got killed anyway.