### PR TITLE
clearPageBits for the processes that are added to the softdirty tracker 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,3 @@ require (
 	golang.org/x/sys v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/baliw/GoSimple v0.0.0-20121217072525-5b4839bab9bc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/baliw/GoSimple v0.0.0-20121217072525-5b4839bab9bc h1:fcS8TphFPDfcJYvq9T0bd+HAZMcL8ICBRE0G6q7rK5Q=
-github.com/baliw/GoSimple v0.0.0-20121217072525-5b4839bab9bc/go.mod h1:NzU9GSYh4oolHYkpLRnsfMT1MZfsm2F84V96D6D72YA=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/test/e2e/memtierd.test-suite/memtierd.source.sh
+++ b/test/e2e/memtierd.test-suite/memtierd.source.sh
@@ -169,7 +169,7 @@ memtierd-match-pagemoving() {
     round_number=0
     while ! (
         memtierd-command "stats -t move_pages -f csv | awk -F, \"{print \\\$6\\\$7}\""
-        grep "${pagemoving_regexp}" <<<"$COMMAND_OUTPUT"
+        grep -E "${pagemoving_regexp}" <<<"$COMMAND_OUTPUT"
     ); do
         echo "grep PAGEMOVING value matching ${pagemoving_regexp} not found"
         next-round round_number "${round_counter_max}" "${round_delay}" || {

--- a/test/e2e/memtierd.test-suite/policy-age/n4c16/test02-swap-softdirty/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-age/n4c16/test02-swap-softdirty/code.var.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+memtierd-setup
+
+# Create swap
+zram-install
+zram-swap off
+zram-swap 2G
+
+# Test meme process which has 1G of memory and reads actively 300M
+# 700M+ should be moved to idlenumas and 300M should be moved to activenumas
+MEME_BS=1G MEME_BWC=1 MEME_BWS=300M memtierd-meme-start
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: age
+  config: |
+    intervalms: 4000
+    pidwatcher:
+      name: pidlist
+      config: |
+        pids:
+          - $MEME_PID
+    swapoutms: 5000
+    tracker:
+      name: softdirty
+      config: |
+        pagesinregion: 256
+        maxcountperregion: 0
+        scanintervalms: 4000
+        regionsupdatems: 0
+        skippageprob: 0
+        pagemapreadahead: 0
+    mover:
+      intervalms: 20
+      bandwidth: 100
+"
+memtierd-start
+
+sleep 4
+
+echo "waiting 700M+ to be paged out..."
+memtierd-match-pageout "0\.7[0-9][0-9]" 5 6
+
+echo "check swap status: correct pages have been paged out."
+memtierd-command "swap -pid $MEME_PID -status"
+grep " 7[0-9][0-9] " <<<"$COMMAND_OUTPUT" || {
+    error "expected 7XX MB of swapped out"
+}
+
+echo "stop meme, expect all memory to be paged out"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pageout "1\.[0-2]" 5 6
+
+echo "continue meme, expect 300 MB to be swapped in by OS"
+vm-command "kill -CONT ${MEME_PID}"
+sleep 4
+memtierd-command "swap -pid $MEME_PID -status"
+grep " 7[0-9][0-9] " <<<$"$COMMAND_OUTPUT" || {
+    error "expected 7XX MB of swapped out"
+}
+
+echo "stop meme again, verify that all memory gets paged out again"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pageout "1\.[2-5]" 5 6
+
+memtierd-stop
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-age/n4c16/test03-move-idlepage/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-age/n4c16/test03-move-idlepage/code.var.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Make sure the system has IDLEPAGE support enabled
+# Note: IDLEPAGE is enabled on ubuntu-22.04 by default
+# shellcheck disable=SC2154
+vm-command "[ -f /sys/kernel/mm/page_idle/bitmap ]" || {
+    if [[ "$distro" != "debian-sid" && "$distro" != "ubuntu-22.04" ]]; then
+        error "idlepage e2e test is implemented only for distro=debian-sid or distro=ubuntu-22.04"
+    fi
+
+    if [ "$distro" == "debian-sid" ]; then
+        damon-idlepage-setup
+    fi
+
+    vm-command "[ -f /sys/kernel/mm/page_idle/bitmap ]" || error "failed to setup idlepage"
+}
+
+memtierd-setup
+
+# Test meme process which has 1G of memory and writes actively 300M
+# 700M+ should be moved to idlenumas and 300M should be moved to activenumas
+MEME_CGROUP=e2e-meme
+MEME_BS=1G MEME_BRC=1 MEME_BRS=300M memtierd-meme-start
+sleep 2
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: age
+  config: |
+    intervalms: 5000
+    pidwatcher:
+      name: cgroups
+      config: |
+        cgroups:
+          - /sys/fs/cgroup/${MEME_CGROUP}
+    idledurationms: 8000
+    idlenumas: [3]
+    activedurationms: 6000
+    activenumas: [1]
+    tracker:
+      name: idlepage
+      config: |
+        pagesinregion: 512
+        maxcountperregion: 1
+        scanintervalms: 4000
+    mover:
+      intervalms: 20
+      bandwidth: 200
+"
+memtierd-start
+
+sleep 4
+
+echo "waiting 200M+ (active) to be moved to node 1 and 700M+ (idle) to be moved to node 3"
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]" 5 6
+memtierd-match-pagemoving "3\:0\.7[0-9][0-9]" 5 6
+
+echo "stop meme, expect all memory to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "3\:1\.[0-2]" 5 6
+
+echo "continue meme, expect ~300 MB to be moved to node 1"
+vm-command "kill -CONT ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.5[0-9][0-9]" 5 6
+
+echo "stop meme again, expect ~300 MB to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "3\:1\.[2-4]" 5 6
+
+memtierd-stop
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-heat/n4c16/test02-move-idlepage/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-heat/n4c16/test02-move-idlepage/code.var.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+memtierd-setup
+
+# Start a process that has 1G of memory and reads actively 260M.
+MEME_CGROUP=e2e-meme
+MEME_BS=1G MEME_BRC=1 MEME_BRS=260M MEME_MEMS=0 memtierd-meme-start
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: heat
+  config: |
+    intervalms: 4000
+    pidwatcher:
+      name: cgroups
+      config: |
+        cgroups:
+          - /sys/fs/cgroup/${MEME_CGROUP}
+    heatnumas:
+      0: [3]
+      1: [1]
+    heatmap:
+      heatmax: 0.01
+      heatretention: 0
+      heatclasses: 2
+    tracker:
+      name: idlepage
+      config: |
+        pagesinregion: 512
+        maxcountperregion: 0
+        scanintervalms: 500
+        regionsupdatems: 0
+        pagemapreadahead: 0
+        kpageflagsreadahead: 0
+        bitmapreadahead: 0
+    mover:
+      intervalms: 20
+      bandwidth: 100
+"
+memtierd-start
+
+sleep 4
+
+echo "waiting ~260 MB (hot) to be moved to node 1 and ~700 MB (cold) to be moved to node 3"
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:0\.7[0-9][0-9]" 5 4
+
+echo "stop meme, expect all memory to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:1\.[0-2]" 3 4
+
+echo "continue meme, expect ~260 MB to be moved back to node 1 again"
+vm-command "kill -CONT ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.5[0-9][0-9]\;3\:1\.[0-2]" 3 4
+
+echo "stop meme again, expect ~260 MB to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.5[0-9][0-9]\;3\:1\.[2-4]" 3 4
+
+memtierd-stop
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-heat/n4c16/test03-move-softdirty/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-heat/n4c16/test03-move-softdirty/code.var.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+memtierd-setup
+
+# Start a process that has 1G of memory and writes actively 260M.
+MEME_CGROUP=e2e-meme
+MEME_BS=1G MEME_BWC=1 MEME_BWS=260M MEME_MEMS=0 memtierd-meme-start
+sleep 2
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: heat
+  config: |
+    intervalms: 4000
+    pidwatcher:
+      name: cgroups
+      config: |
+        cgroups:
+          - /sys/fs/cgroup/${MEME_CGROUP}
+    heatnumas:
+      0: [3]
+      1: [1]
+    heatmap:
+      heatmax: 0.01
+      heatretention: 0
+      heatclasses: 2
+    tracker:
+      name: softdirty
+      config: |
+        pagesinregion: 512
+        maxcountperregion: 0
+        scanintervalms: 500
+        regionsupdatems: 0
+    mover:
+      intervalms: 20
+      bandwidth: 100
+"
+memtierd-start
+
+sleep 4
+
+echo "waiting ~260 MB (hot) to be moved to node 1 and ~700 MB (cold) to be moved to node 3"
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:0\.7[0-9][0-9]" 5 4
+
+echo "stop meme, expect all memory to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:1\.[0-2]" 3 4
+
+echo "continue meme, expect ~260 MB to be moved back to node 1 again"
+vm-command "kill -CONT ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.5[0-9][0-9]\;3\:1\.[0-2]" 3 4
+
+echo "stop meme again, expect ~260 MB to be moved to node 3"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "1\:0.5[0-9][0-9]\;3\:1\.[2-4]" 3 4
+
+memtierd-stop
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-ratio/n4c16/test01-move/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-ratio/n4c16/test01-move/code.var.sh
@@ -50,7 +50,7 @@ policy:
 memtierd-start
 
 sleep 5
-memtierd-match-pagemoving "3\:0.3[5-9][0-9]" 5 5
+memtierd-match-pagemoving "3\:0.(3[5-9][0-9]|4[0-4][0-9]|450)" 5 5
 
 memtierd-stop
 memtierd-meme-stop
@@ -87,7 +87,7 @@ policy:
 memtierd-start
 
 sleep 5
-memtierd-match-pagemoving "3\:0.3[5-9][0-9]" 5 5
+memtierd-match-pagemoving "3\:0.(3[5-9][0-9]|4[0-4][0-9]|450)" 5 5
 
 memtierd-stop
 memtierd-meme-stop


### PR DESCRIPTION
This pr also includes:
- add e2e tests of moving memories among numa nodes with softdirty tracker and with idlepage tracker for policy heat
- add two more e2e test cases for policy age, one is swapping memories with softdirty tracker, the other is moving memoeries among numa nodes with idlepage tracker
- modify the range of moving pages for test01-move e2e test of policy-ratio