### PR TITLE
Improve errcheck/logging for yaml/json configuration from the user

### DIFF
--- a/cmd/memtierd/main.go
+++ b/cmd/memtierd/main.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/intel/memtierd/pkg/memtier"
 	_ "github.com/intel/memtierd/pkg/version"
 )
@@ -43,10 +41,19 @@ func loadConfigFile(filename string) (memtier.Policy, []memtier.Routine) {
 	if err != nil {
 		exit("%s", err)
 	}
+
 	var config config
-	err = yaml.Unmarshal(configBytes, &config)
+	err = memtier.UnmarshalYamlConfig(configBytes, &config)
 	if err != nil {
 		exit("error in %q: %s", filename, err)
+	}
+
+	if config.Policy == (memtier.PolicyConfig{}) {
+		exit("error in policy field or missing")
+	}
+
+	if config.Policy.Name == "" {
+		exit("error in policy.name filed or missing")
 	}
 
 	policy, err := memtier.NewPolicy(config.Policy.Name)

--- a/pkg/memtier/heatforecaster_chain.go
+++ b/pkg/memtier/heatforecaster_chain.go
@@ -42,7 +42,7 @@ func NewHeatForecasterChain() (HeatForecaster, error) {
 // SetConfigJSON sets the configuration for the HeatForecasterChain from a JSON string.
 func (hf *HeatForecasterChain) SetConfigJSON(configJSON string) error {
 	config := &HeatForecasterChainConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	return hf.SetConfig(config)

--- a/pkg/memtier/heatforecaster_stdio.go
+++ b/pkg/memtier/heatforecaster_stdio.go
@@ -54,7 +54,7 @@ func NewHeatForecasterStdio() (HeatForecaster, error) {
 // SetConfigJSON sets the configuration for HeatForecasterStdio from a JSON string.
 func (hf *HeatForecasterStdio) SetConfigJSON(configJSON string) error {
 	config := &HeatForecasterStdioConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	return hf.SetConfig(config)

--- a/pkg/memtier/heatforecaster_trace.go
+++ b/pkg/memtier/heatforecaster_trace.go
@@ -45,7 +45,7 @@ func NewHeatForecasterTrace() (HeatForecaster, error) {
 // SetConfigJSON sets the configuration for the HeatForecasterTrace from a JSON string.
 func (hf *HeatForecasterTrace) SetConfigJSON(configJSON string) error {
 	config := &HeatForecasterTraceConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	return hf.SetConfig(config)

--- a/pkg/memtier/mover.go
+++ b/pkg/memtier/mover.go
@@ -108,7 +108,7 @@ func (mt *MoverTask) String() string {
 // SetConfigJSON sets the configuration of the Mover from a JSON string.
 func (m *Mover) SetConfigJSON(configJSON string) error {
 	var config MoverConfig
-	if err := unmarshal(configJSON, &config); err != nil {
+	if err := UnmarshalConfig(configJSON, &config); err != nil {
 		return err
 	}
 	return m.SetConfig(&config)

--- a/pkg/memtier/pidwatcher_cgroups.go
+++ b/pkg/memtier/pidwatcher_cgroups.go
@@ -59,7 +59,7 @@ func (w *PidWatcherCgroups) SetConfigJSON(configJSON string) error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	config := &PidWatcherCgroupsConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	if config.IntervalMs == 0 {

--- a/pkg/memtier/pidwatcher_filter.go
+++ b/pkg/memtier/pidwatcher_filter.go
@@ -64,7 +64,7 @@ func (w *PidWatcherFilter) SetConfigJSON(configJSON string) error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	config := &PidWatcherFilterConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	newSource, err := NewPidWatcher(config.Source.Name)

--- a/pkg/memtier/pidwatcher_pidlist.go
+++ b/pkg/memtier/pidwatcher_pidlist.go
@@ -47,7 +47,7 @@ func (w *PidWatcherPidlist) SetConfigJSON(configJSON string) error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	config := &PidWatcherPidlistConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	w.config = config

--- a/pkg/memtier/pidwatcher_proc.go
+++ b/pkg/memtier/pidwatcher_proc.go
@@ -60,7 +60,7 @@ func (w *PidWatcherProc) SetConfigJSON(configJSON string) error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 	config := &PidWatcherProcConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	if config.IntervalMs == 0 {

--- a/pkg/memtier/routine_statactions.go
+++ b/pkg/memtier/routine_statactions.go
@@ -100,7 +100,7 @@ func NewRoutineStatActions() (Routine, error) {
 // SetConfigJSON sets the configuration for the StatActions routine from a JSON string.
 func (r *RoutineStatActions) SetConfigJSON(configJSON string) error {
 	config := &RoutineStatActionsConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	if config.IntervalMs <= 0 {

--- a/pkg/memtier/tracker_damon.go
+++ b/pkg/memtier/tracker_damon.go
@@ -165,7 +165,7 @@ func NewTrackerDamon() (Tracker, error) {
 func (t *TrackerDamon) SetConfigJSON(configJSON string) error {
 	config := &TrackerDamonConfig{}
 	if configJSON != "" {
-		if err := unmarshal(configJSON, config); err != nil {
+		if err := UnmarshalConfig(configJSON, config); err != nil {
 			return err
 		}
 	}

--- a/pkg/memtier/tracker_finder.go
+++ b/pkg/memtier/tracker_finder.go
@@ -77,7 +77,7 @@ func NewTrackerFinder() (Tracker, error) {
 // SetConfigJSON sets the configuration for TrackerFinder from a JSON string.
 func (t *TrackerFinder) SetConfigJSON(configJSON string) error {
 	config := &TrackerFinderConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	t.config = config

--- a/pkg/memtier/tracker_idlepage.go
+++ b/pkg/memtier/tracker_idlepage.go
@@ -99,7 +99,7 @@ func NewTrackerIdlePage() (Tracker, error) {
 // SetConfigJSON sets the configuration for TrackerIdlePage from a JSON string.
 func (t *TrackerIdlePage) SetConfigJSON(configJSON string) error {
 	config := &TrackerIdlePageConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	t.config = config

--- a/pkg/memtier/tracker_multi.go
+++ b/pkg/memtier/tracker_multi.go
@@ -45,7 +45,7 @@ func NewTrackerMulti() (Tracker, error) {
 // SetConfigJSON sets the configuration for multiple trackers from a JSON string.
 func (t *TrackerMulti) SetConfigJSON(configJSON string) error {
 	config := &TrackerMultiConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	t.trackers = make([]Tracker, len(config.Trackers))

--- a/pkg/memtier/tracker_softdirty.go
+++ b/pkg/memtier/tracker_softdirty.go
@@ -102,7 +102,7 @@ func NewTrackerSoftDirty() (Tracker, error) {
 // SetConfigJSON sets the configuration for TrackerSoftDirty from a JSON string.
 func (t *TrackerSoftDirty) SetConfigJSON(configJSON string) error {
 	config := &TrackerSoftDirtyConfig{}
-	if err := unmarshal(configJSON, config); err != nil {
+	if err := UnmarshalConfig(configJSON, config); err != nil {
 		return err
 	}
 	t.config = config

--- a/pkg/memtier/unmarshal.go
+++ b/pkg/memtier/unmarshal.go
@@ -16,15 +16,61 @@ package memtier
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-func unmarshal(jsonOrYaml string, obj interface{}) error {
-	if err := json.Unmarshal([]byte(jsonOrYaml), obj); err != nil {
-		if err := yaml.Unmarshal([]byte(jsonOrYaml), obj); err != nil {
-			return err
+// convertYamlKeysToLower converts yaml's all fileds' name to lower anyway, thus,
+// memtierd could be case-insensitive for the keys
+func convertYamlKeysToLower(in []byte) ([]byte, error) {
+	lines := []string{}
+	for _, line := range strings.Split(string(in), "\n") {
+		if strings.Contains(line, ":") {
+			parts := strings.SplitN(line, ":", 2)
+			line = fmt.Sprintf("%s:%s", strings.ToLower(parts[0]), parts[1])
+		}
+		lines = append(lines, line)
+	}
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+// UnmarshalYamlConfig will unmarshal yaml configuration and convert keys to lower cases
+func UnmarshalYamlConfig(yamlData []byte, obj interface{}) error {
+	err := yaml.Unmarshal(yamlData, obj)
+	if err == nil {
+		newYamlData, errx := convertYamlKeysToLower(yamlData)
+		if errx != nil {
+			return fmt.Errorf("failed to convertYamlKeysToLower config data: %s with err: %w", yamlData, errx)
+		}
+
+		erry := yaml.Unmarshal(newYamlData, obj)
+		if erry != nil {
+			return fmt.Errorf("failed to yaml.Unmarshal new config data: %s with err: %w", newYamlData, erry)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("failed to yaml.Unmarshal config data: %s with err: %w", yamlData, err)
+}
+
+// UnmarshalConfig will unmarshal yaml configuration and convert keys to lower cases if the
+// configuration is yaml, or unmarshal json configuration if the configuration is json
+func UnmarshalConfig(jsonOrYaml string, obj interface{}) error {
+	// attempt to unmarshal yaml configuration and convert keys to lower cases
+	err := UnmarshalYamlConfig([]byte(jsonOrYaml), obj)
+	if err != nil {
+		errx := json.Unmarshal([]byte(jsonOrYaml), obj)
+		if errx != nil {
+			return fmt.Errorf("failed to yaml.Unmarshal config data: %s with err: %w, json.Unmarshal config data with err: %w", jsonOrYaml, err, errx)
 		}
 	}
-	return nil
+	// attempt to unmarshal json configuration
+	if err := json.Unmarshal([]byte(jsonOrYaml), obj); err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("failed to unmarshal config data: %s", jsonOrYaml)
 }


### PR DESCRIPTION
With this PR, when the user give either Upper or Lower cases' Keys in the yaml, memtierd could process the yaml anyway. eg,
```yaml
MEMTIERD_YAML="
policy:
  **NaMe**: heat
  config: |
...
    **heatmaP**:
      heatmax: 0.01
      heatretention: 0.92
      heatclasses: 5
    **tRacker**:
      name: idlepage
      config: |
        pagesinregion: 512
        maxcountperregion: 1
        scanintervalms: 4000
    **movEr**:
      intervalms: 20
      bandwidth: 1000
"

# After processing,

config.Policy: {heat intervalms: 4000
...
heatmap:
  heatmax: 0.01
  heatretention: 0.92
  heatclasses: 5
tracker:
  name: idlepage
  config: |
    pagesinregion: 512
    maxcountperregion: 1
    scanintervalms: 4000
mover:
  intervalms: 20
  bandwidth: 1000
}
config.Policy.Name: heat
```