### PR TITLE
e2e: more robust heat/idlepage test

### DIFF
--- a/test/e2e/memtierd.test-suite/policy-heat/n4c16/test02-move-idlepage/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-heat/n4c16/test02-move-idlepage/code.var.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+thp-enable
 memtierd-setup
 
 # Start a process that has 1G of memory and reads actively 260M.
@@ -43,7 +44,7 @@ memtierd-start
 sleep 4
 
 echo "waiting ~260 MB (hot) to be moved to node 1 and ~700 MB (cold) to be moved to node 3"
-memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:0\.7[0-9][0-9]" 5 4
+memtierd-match-pagemoving "1\:0.2[0-9][0-9]\;3\:0\.[78][0-9][0-9]" 5 4
 
 echo "stop meme, expect all memory to be moved to node 3"
 vm-command "kill -STOP ${MEME_PID}"

--- a/test/e2e/memtierd.test-suite/thp.source.sh
+++ b/test/e2e/memtierd.test-suite/thp.source.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+thp-enable() {
+    vm-command '
+    THPEN=/sys/kernel/mm/transparent_hugepage/enabled
+    set -x
+    grep -q "\[always\]" $THPEN || echo always > $THPEN
+    cat $THPEN'
+    if ! grep -q "\[always\]" <<< "$COMMAND_OUTPUT"; then
+        error "enabling transparent hugepages failed"
+    fi
+}
+
+thp-disable() {
+    vm-command '
+    THPEN=/sys/kernel/mm/transparent_hugepage/enabled
+    set -x
+    grep -q "\[never\]" $THPEN || echo never > $THPEN
+    cat $THPEN'
+    if ! grep -q "\[never\]" <<< "$COMMAND_OUTPUT"; then
+        error "disabling transparent hugepages failed"
+    fi
+}


### PR DESCRIPTION
The idlepage test failes if vm does not have THP enabled, or if meme has been built with make DEBUG=1. This patch fixes the first issue by making sure that THP is enabled, and the second issue by relaxing the amount of cold memory that is expected to be moved.