### PR TITLE
memtierd: redesign command line arguments

### DIFF
--- a/cmd/memtierd/main.go
+++ b/cmd/memtierd/main.go
@@ -75,38 +75,61 @@ func loadConfigFile(filename string) (memtier.Policy, []memtier.Routine) {
 }
 
 func main() {
-	memtier.SetLogger(log.New(os.Stderr, "", 0))
-	optPrompt := flag.Bool("prompt", false, "launch interactive prompt (ignore other parameters)")
-	optConfig := flag.String("config", "", "launch non-interactive mode with config file")
-	optConfigDumpJSON := flag.Bool("config-dump-json", false, "dump effective configuration in JSON")
-	optDebug := flag.Bool("debug", false, "print debug output")
-	optCommandString := flag.String("c", "-", "run command string, \"-\": from stdin (the default), \"\": non-interactive")
+	optPrompt := flag.Bool("prompt", false, "Run commands from standard input (after commands from -c and -f)")
+	optConfig := flag.String("config", "", "Load policy and routines from a config FILE")
+	optDebug := flag.Bool("debug", false, "Print debug output")
+	optCommandString := flag.String("c", "", "Run commands from STRING")
+	optCommandFile := flag.String("f", "", "Run commands from FILE")
+	optLog := flag.String("l", "", "Write log to FILE, supports \"stdout\" and \"stderr\"")
+	optEcho := flag.Bool("echo", false, "Echo commands before executing, affects -c, -f, and -prompt")
 
 	flag.Parse()
+
+	switch *optLog {
+	case "", "stderr":
+		memtier.SetLogger(log.New(os.Stderr, "", 0))
+	case "-", "stdout":
+		memtier.SetLogger(log.New(os.Stdout, "", 0))
+	default:
+		logFile, err := os.OpenFile(*optLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			exit("failed to open log file %q: %v", *optLog, err)
+		}
+		memtier.SetLogger(log.New(logFile, "", 0))
+	}
 	memtier.SetLogDebug(*optDebug)
 
-	if *optPrompt {
-		prompt := memtier.NewPrompt("memtierd> ", bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout))
-		prompt.Interact()
-		return
+	// Create policy/routines and run commands in the following order:
+	// 1. parse config file, start policy and routines if present
+	// 2. run string commands from command line
+	// 3. run command file from command file
+	// 4. run commands from standard input (interactive mode)
+	// Quitting interactive prompt exits memtierd immediately.
+	// Otherwise (no interactive prompt or it is not quitting) if policy
+	// or routines are configured, memtierd will not exit.
+
+	if *optConfig == "" && *optCommandString == "" && *optCommandFile == "" && !*optPrompt {
+		exit("required at least one of: -config CONFIGFILE, -c COMMANDS, -f COMMANDFILE, or -prompt")
+	}
+
+	var prompt *memtier.Prompt
+	if *optPrompt || *optCommandFile != "" || *optCommandString != "" {
+		prompt = memtier.NewPrompt("memtierd> ", bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout))
+		prompt.SetEcho(*optEcho)
 	}
 
 	var policy memtier.Policy
 	var routines []memtier.Routine
 	if *optConfig != "" {
 		policy, routines = loadConfigFile(*optConfig)
-	} else {
-		exit("missing -prompt or -config")
-	}
-
-	if *optConfigDumpJSON {
-		fmt.Printf("%s\n", policy.GetConfigJSON())
-		os.Exit(0)
 	}
 
 	if policy != nil {
 		if err := policy.Start(); err != nil {
 			exit("error in starting policy: %s", err)
+		}
+		if prompt != nil {
+			prompt.SetPolicy(policy)
 		}
 	}
 
@@ -120,25 +143,33 @@ func main() {
 			exit("error in starting routine %d: %s", r+1, err)
 		}
 	}
+	if prompt != nil {
+		prompt.SetRoutines(routines)
+	}
 
 	if *optCommandString != "" {
-		var prompt *memtier.Prompt
-		if *optCommandString == "-" {
-			prompt = memtier.NewPrompt("memtierd> ", bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout))
-			if stdinFileInfo, _ := os.Stdin.Stat(); (stdinFileInfo.Mode() & os.ModeCharDevice) == 0 {
-				// Input comes from a pipe.
-				// Echo commands after prompt in the interaction to explain outputs.
-				prompt.SetEcho(true)
-			}
-		} else {
-			prompt = memtier.NewPrompt("", bufio.NewReader(strings.NewReader(*optCommandString)), bufio.NewWriter(os.Stdout))
-		}
-		prompt.SetPolicy(policy)
-		if len(routines) > 0 {
-			prompt.SetRoutines(routines)
-		}
+		prompt.SetInput(bufio.NewReader(strings.NewReader(*optCommandString)))
+		memtier.Log().Debugf("executing commands from command line")
 		prompt.Interact()
-	} else { // *optCommandString == ""
+	}
+
+	if *optCommandFile != "" {
+		commandFile, err := os.Open(*optCommandFile)
+		if err != nil {
+			exit("error in opening command file %q: %v", *optCommandFile, err)
+		}
+		prompt.SetInput(bufio.NewReader(commandFile))
+		memtier.Log().Debugf("executing commands from file %q", *optCommandFile)
+		prompt.Interact()
+		commandFile.Close()
+	}
+
+	if *optPrompt {
+		prompt.SetInput(bufio.NewReader(os.Stdin))
+		memtier.Log().Debugf("executing commands from standard input")
+		prompt.Interact()
+	} else if policy != nil || len(routines) > 0 {
+		memtier.Log().Debugf("running the policy and routines")
 		select {}
 	}
 }

--- a/pkg/memtier/prompt.go
+++ b/pkg/memtier/prompt.go
@@ -203,6 +203,11 @@ func (p *Prompt) SetEcho(newEcho bool) {
 	p.echo = newEcho
 }
 
+// SetInput changes the reader from which interactive prompt reads input.
+func (p *Prompt) SetInput(reader *bufio.Reader) {
+	p.r = reader
+}
+
 // SetPolicy sets the policy for the prompt.
 func (p *Prompt) SetPolicy(policy Policy) {
 	p.policy = policy

--- a/test/e2e/memtierd.test-suite/memtierd.source.sh
+++ b/test/e2e/memtierd.test-suite/memtierd.source.sh
@@ -76,10 +76,10 @@ memtierd-start() {
         vm-command "echo 0-3 > /sys/fs/cgroup/$MEME_CGROUP/cpuset.mems"
     fi
     if [ -z "${MEMTIERD_YAML}" ]; then
-        MEMTIERD_OPTS="-prompt -debug"
+        MEMTIERD_OPTS="-prompt -debug -echo"
     else
         vm-pipe-to-file "memtierd.yaml" <<<"${MEMTIERD_YAML}"
-        MEMTIERD_OPTS="-config memtierd.yaml -debug"
+        MEMTIERD_OPTS="-config memtierd.yaml -prompt -debug -echo"
     fi
     vm-command "nohup sh -c 'socat tcp4-listen:${MEMTIERD_PORT},fork,reuseaddr - | memtierd ${MEMTIERD_OPTS}' > ${MEMTIERD_OUTPUT} 2>&1 & sleep 2; cat ${MEMTIERD_OUTPUT}"
     vm-command "pgrep memtierd" || {


### PR DESCRIPTION
- Introduce three ways to run memtierd commands, any combination of which is allowed and makes perfect sense. In the order of execution the ways are: command line arguments (-c COMMANDS), command file (-f FILE) and the interactive prompt (--prompt).
- Show interactive prompt only if requested by the user (--prompt).
- Add logging into a file (-l FILE).
- Add option for echoing executed commands from any source (--echo).
- Drop --config-dump.
- Update the command line parameters with which memtierd is launched in e2e tests.