### PR TITLE
prompt: add shell-like semantics to ', " and \ in commands

### DIFF
--- a/pkg/memtier/prompt.go
+++ b/pkg/memtier/prompt.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 // Cmd represents a command with a description and a function to execute.
@@ -129,6 +130,63 @@ func (p *Prompt) RunCmdSlice(cmdSlice []string) CommandStatus {
 	return cmd.Run(cmdSlice[1:])
 }
 
+// cmdStringToSlice enables quoting parameters that contain spaces
+// with single and double quotes and escaping.
+func cmdStringToSlice(raw string) ([]string, error) {
+	var args []string
+	var currentArg string
+	var quoteStart rune
+	var quoteEnd rune
+	startEnd := map[rune]rune{
+		'"':  '"',
+		'\'': '\'',
+	}
+	escape := '\\'
+	escaped := false
+	quoted := false
+	for _, c := range raw {
+		if escaped {
+			currentArg += string(c)
+			escaped = false
+			continue
+		}
+		if c == escape {
+			escaped = true
+			continue
+		}
+		if !quoted {
+			if unicode.IsSpace(c) {
+				if currentArg != "" {
+					args = append(args, currentArg)
+				}
+				currentArg = ""
+				continue
+			}
+			if quoteEnd, quoted = startEnd[c]; quoted {
+				quoteStart = c
+				continue
+			}
+			currentArg += string(c)
+		} else {
+			if c == quoteEnd {
+				quoted = false
+				continue
+			}
+			currentArg += string(c)
+		}
+	}
+	if escaped {
+		return args, fmt.Errorf("missing escaped character")
+	}
+	if quoted {
+		return args, fmt.Errorf("unterminated quoted (%c) string", quoteStart)
+	}
+	if currentArg != "" {
+		args = append(args, currentArg)
+	}
+	return args, nil
+}
+
 // RunCmdString executes a command specified by a string.
 func (p *Prompt) RunCmdString(cmdString string) CommandStatus {
 	p.mutex.Lock()
@@ -144,8 +202,11 @@ func (p *Prompt) RunCmdString(cmdString string) CommandStatus {
 		pipeCmd = cmdString[pipeIndex+1:]
 		cmdString = cmdString[:pipeIndex]
 	}
-	// TODO: consider shlex-like splitting.
-	cmdSlice := strings.Split(strings.TrimSpace(cmdString), " ")
+	cmdSlice, err := cmdStringToSlice(strings.TrimSpace(cmdString))
+	if err != nil {
+		p.output("error in command %q: %s", cmdString, err)
+		return csError
+	}
 
 	// If there is a pipe, redirect p.output() (that is, p.w) to
 	// the pipe before calling cmd<Function>.

--- a/pkg/memtier/prompt_test.go
+++ b/pkg/memtier/prompt_test.go
@@ -24,6 +24,19 @@ import (
 	"time"
 )
 
+func verifyStringSlice(t *testing.T, input string, exp, obs []string) {
+	if len(exp) != len(obs) {
+		t.Errorf("input %q: slice lengths (%d vs %d) differ: expected %v, observed %v", input, len(exp), len(obs), exp, obs)
+		return
+	}
+	for i := range exp {
+		if exp[i] != obs[i] {
+			t.Errorf("input %q: exp[%d]==%q != obs[%d]==%q: expected %v, obsreved %v", input, i, exp[i], i, obs[i], exp, obs)
+			return
+		}
+	}
+}
+
 func FuzzPrompt(f *testing.F) {
 	fuzzPromptCreateEnv := os.Getenv("FUZZ_PROMPT_CREATE")
 	fuzzPromptCreate := true
@@ -104,4 +117,55 @@ func FuzzPrompt(f *testing.F) {
 		}
 
 	})
+}
+
+func TestCmdStringToSlice(t *testing.T) {
+	tcases := []struct {
+		name        string
+		input       string
+		expected    []string
+		expectedErr string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "double and single quotes",
+			input:    "-f \"double quotes\" -s 'single quotes'",
+			expected: []string{"-f", "double quotes", "-s", "single quotes"},
+		},
+		{
+			name:     "escaped quotes",
+			input:    "5\\' 3\\\"",
+			expected: []string{"5'", "3\""},
+		},
+		{
+			name:     "escaped quotes in quotes",
+			input:    "\"5' 3\\\"\" or '5\\' 3\"'",
+			expected: []string{"5' 3\"", "or", "5' 3\""},
+		},
+		{
+			name:        "quoted spaces and a runaway quote",
+			input:       "this\\ is\" \"fine isn\\'t' 'it but-this-isn't",
+			expected:    []string{"this is fine", "isn't it"},
+			expectedErr: "unterminated quoted (') string",
+		},
+		{
+			name:        "bad escape",
+			input:       "there is nothing worse than \\",
+			expected:    []string{"there", "is", "nothing", "worse", "than"},
+			expectedErr: "missing escaped character",
+		},
+	}
+	for _, tc := range tcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed, err := cmdStringToSlice(tc.input)
+			if tc.expectedErr != "" && (err == nil || err.Error() != tc.expectedErr) {
+				t.Errorf("input %q expected error %v observed %v", tc.input, tc.expectedErr, err)
+			}
+			verifyStringSlice(t, tc.input, tc.expected, observed)
+		})
+	}
 }

--- a/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
+++ b/test/e2e/memtierd.test-suite/no-policy/n4c16/test01-mover/code.var.sh
@@ -52,9 +52,9 @@ match-pid-swapped() {
 
 mover_conf=(
     '-config-dump'
-    '-config {"IntervalMs":1000,"Bandwidth":100000}'
-    '-config {"IntervalMs":10,"Bandwidth":200}'
-    '-config {"IntervalMs":20,"Bandwidth":500}'
+    '-config "{\\"IntervalMs\\":1000,\\"Bandwidth\\":100000}"'
+    '-config "{\\"IntervalMs\\":10,\\"Bandwidth\\":200}"'
+    '-config "{\\"IntervalMs\\":20,\\"Bandwidth\\":500}"'
 )
 
 declare -A mover_seconds=(
@@ -65,9 +65,9 @@ declare -A mover_seconds=(
 )
 
 mover_swap_conf=(
-    '-config {"IntervalMs":10,"Bandwidth":5}'
-    '-config {"IntervalMs":20,"Bandwidth":10}'
-    '-config {"IntervalMs":1000,"Bandwidth":10}'
+    '-config {\\"IntervalMs\\":10,\\"Bandwidth\\":5}'
+    '-config {\\"IntervalMs\\":20,\\"Bandwidth\\":10}'
+    '-config {\\"IntervalMs\\":1000,\\"Bandwidth\\":10}'
 )
 
 declare -A mover_swap_seconds=(
@@ -139,7 +139,7 @@ vm-command "mkdir -p /sys/fs/cgroup/e2e-meme; echo ${MEME2_PID} > /sys/fs/cgroup
 
 # the 1st time swapping out with -mover option for the three meme processes.
 # Test all methods to give PIDs to swap: -pid, -pids and -pid-cgroups.
-memtierd-command "mover -config {\"IntervalMs\":10,\"Bandwidth\":10}\nswap -out -pids ${MEME0_PID} -pid ${MEME1_PID} -pid-cgroups /sys/fs/cgroup/e2e-meme -mover\nmover -wait"
+memtierd-command "mover -config \"{\\\"IntervalMs\\\":10,\\\"Bandwidth\\\":10}\"\nswap -out -pids ${MEME0_PID} -pid ${MEME1_PID} -pid-cgroups /sys/fs/cgroup/e2e-meme -mover\nmover -wait"
 
 # As mover handles the multiple pids' tasks one by one, thus, set the max_seconds four times greater and set the min_seconds as 0
 for MEME_PID in "${MEME_PIDS[@]}"; do

--- a/test/e2e/memtierd.test-suite/no-policy/n4c16/test02-tracker-finder/code.var.sh
+++ b/test/e2e/memtierd.test-suite/no-policy/n4c16/test02-tracker-finder/code.var.sh
@@ -33,7 +33,7 @@ fi
 echo -e "$PARSED_AR"
 eval "$PARSED_AR"
 
-memtierd-command "tracker -create finder -config {\"ReportAccesses\":42} -config-dump -start ${MEME_PID} -counters"
+memtierd-command "tracker -create finder -config {\\\"ReportAccesses\\\":42} -config-dump -start ${MEME_PID} -counters"
 echo -e "\n# Expect a=42 ... $startall-$endall to be found from the counters:"
 if ! grep "a=42 .*$startall-$endall" <<< "$COMMAND_OUTPUT"; then
     error "cannot find the large block with 42 accesses from counters"
@@ -42,13 +42,13 @@ fi
 echo ""
 echo "# Swap out an address range and verify that the finder finds pages that are not present"
 memtierd-command "swap -pid ${MEME_PID} -out -ranges $startmid-$endmid"
-memtierd-command "tracker -create finder -config {\"PagemapBitPresent\":false} -config-dump -start ${MEME_PID} -counters"
+memtierd-command "tracker -create finder -config {\\\"PagemapBitPresent\\\":false} -config-dump -start ${MEME_PID} -counters"
 echo -e "\n# Expect a=0 ... $startmid-$endmid to be found from the counters:"
 if ! grep "a=0 .*$startmid-$endmid" <<< "$COMMAND_OUTPUT"; then
     error "cannot find pages that should have been marked as not present"
 fi
 echo -e "\n# Expect $startall-$startmid and $endmid-$endall are found when looking for pages present in memory"
-memtierd-command "tracker -create finder -config {\"PagemapBitPresent\":true} -config-dump -start ${MEME_PID} -counters"
+memtierd-command "tracker -create finder -config {\\\"PagemapBitPresent\\\":true} -config-dump -start ${MEME_PID} -counters"
 echo -e "\n# Expect a=0 ...-$startmid and $endmid-... to be found from the counters:"
 # Note that we cannot assume that $startall-$startmid would be all present in memory
 # because (especially when THP is not used) this range may be allocated to the application
@@ -61,7 +61,7 @@ fi
 if ! grep "$endmid-" <<< "$COMMAND_OUTPUT"; then
     error "cannot find pages $endmid-..."
 fi
-memtierd-command "tracker -create finder -config {\"ReportAccesses\":2,\"PagemapBitSoftDirty\":true} -config-dump -start ${MEME_PID} -counters"
+memtierd-command "tracker -create finder -config \"{\\\"ReportAccesses\\\":2, \\\"PagemapBitSoftDirty\\\":true}\" -config-dump -start ${MEME_PID} -counters"
 echo -e "\n# Expect $startall-$endall reported even if $startmid-$endmid is not present and scanning softdirty pages"
 CHECK_RESULT=$(grep -E 'ranges=' <<< "$COMMAND_OUTPUT" | sed -e 's/.*ranges=//g' -e 's/[- ()]/ /g' | while read -r start end size remainder; do
                 if (( "0x$start" <=  "0x$startall" )) && (( "0x$end" >= "0x$endall" )); then


### PR DESCRIPTION
Quotation and escaping in memtier prompt command parser enables command arguments to include whitespace. As the syntax is shell-like, parsing feels the same in both sides of piped prompt commands (MEMTIER-COMMAND | SHELL-COMMAND). Corresponding updates made to e2e tests.