### PR TITLE
ci: disable cyclomatic check

### DIFF
--- a/.github/workflows/common-verify-code.yaml
+++ b/.github/workflows/common-verify-code.yaml
@@ -58,10 +58,6 @@ jobs:
     - name: Golangci lint check
       run: make golangci-lint
 
-      # FIXME(Jing Yan): once the following static checks are fixed, uncomment the following steps.
-    # - name: Cyclomatic check
-    #   run: make cyclomatic-check
-
     - name: Unit test
       run: make race=1 test
 


### PR DESCRIPTION
fix the remaining cyclomatic check issues might violate the readability and maintainability, thus, delete the cyclomatic check in ci currently