### PR TITLE
memtierd: unknown fields in json and yaml are treated as errors

### DIFF
--- a/pkg/memtier/pidwatcher_proc.go
+++ b/pkg/memtier/pidwatcher_proc.go
@@ -50,7 +50,7 @@ func NewPidWatcherProc() (PidWatcher, error) {
 	}
 	// This pidwatcher is expected to work out-of-the-box without
 	// any configuration. Set the defaults immediately.
-	_ = w.SetConfigJSON("")
+	_ = w.SetConfigJSON("{}")
 	return w, nil
 }
 

--- a/pkg/memtier/unmarshal.go
+++ b/pkg/memtier/unmarshal.go
@@ -16,13 +16,18 @@ package memtier
 
 import (
 	"encoding/json"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 func unmarshal(jsonOrYaml string, obj interface{}) error {
-	if err := json.Unmarshal([]byte(jsonOrYaml), obj); err != nil {
-		if err := yaml.Unmarshal([]byte(jsonOrYaml), obj); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(jsonOrYaml))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(obj); err != nil {
+		decoder := yaml.NewDecoder(strings.NewReader(jsonOrYaml))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(obj); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
- Support json and yaml parser syntax and capitalization.
- Return errors from unmarshaling configurations with unknown fields.
- Improve error messages from memtierd -config issues.