### PR TITLE
memtierd: fix running single commands from command-line

### DIFF
--- a/cmd/memtierd/main.go
+++ b/cmd/memtierd/main.go
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	if *optCommandString != "" {
-		prompt.SetInput(bufio.NewReader(strings.NewReader(*optCommandString)))
+		prompt.SetInput(bufio.NewReader(strings.NewReader(*optCommandString + "\n")))
 		memtier.Log().Debugf("executing commands from command line")
 		prompt.Interact()
 	}


### PR DESCRIPTION
"memtierd -c help" returned immediately eof without running the command.