### PR TITLE
Fix the CI error fo "perform CodeQL Analysis"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/intel/memtierd
 
-go 1.22
+go 1.22.0
 
 require (
 	golang.org/x/sys v0.8.0


### PR DESCRIPTION
modify go version from 1.22 to 1.22.0 so that the following error could be avoided.

go: download go1.22 for linux/amd64: toolchain not available, Error: Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/2.16.3/x64/codeql/go/tools/autobuild.sh"

Changes have been tested with https://github.com/yanjing1104/memtierd/pull/7, codeql-scan passed successfully.