### PR TITLE
e2e: support up to 4096 CPU virtual machines

### DIFF
--- a/test/e2e/lib/topology2qemuopts.py
+++ b/test/e2e/lib/topology2qemuopts.py
@@ -24,6 +24,8 @@ NUMA node group definitions:
                       The default is 1.
 "packages"            number of packages.
                       The default is 1.
+"cpus-present"        number of logical CPUs that are present at startup.
+                      The default value 0 means "all".
 
 NUMA node distances are defined with following keys:
 "dist-all": [[from0to0, from0to1, ...], [from1to0, from1to1, ...], ...]
@@ -105,13 +107,15 @@ def validate(numalist):
         raise ValueError('expected list containing dicts, got %s' % (type(numalist,).__name__))
     valid_keys = set(("mem", "nvmem", "dimm",
                       "cores", "threads", "nodes", "dies", "packages",
+                      "cpus-present",
                       "node-dist", "dist-all",
                       "dist-other-package", "dist-same-package", "dist-same-die"))
     int_range_keys = {'cores': ('>= 0', lambda v: v >= 0),
                       'threads': ('> 0', lambda v: v > 0),
                       'nodes': ('> 0', lambda v: v > 0),
                       'dies': ('> 0', lambda v: v > 0),
-                      'packages': ('> 0', lambda v: v > 0)}
+                      'packages': ('> 0', lambda v: v > 0),
+                      'cpus-present': ('>= 0', lambda v: v >=0)}
     for numalistindex, numaspec in enumerate(numalist):
         for key in numaspec:
             if not key in valid_keys:
@@ -207,12 +211,14 @@ def dists(numalist):
     return dist_dict
 
 def qemuopts(numalist):
-    machineparam = "-machine pc"
+    machineparam = "-machine q35,kernel-irqchip=split"
+    cpuparam = "-cpu host,x2apic=on"
     numaparams = []
     objectparams = []
     deviceparams = []
     lastnode = -1
     lastcpu = -1
+    lastcpupresent = -1
     lastdie = -1
     lastsocket = -1
     lastmem = -1
@@ -246,6 +252,7 @@ def qemuopts(numalist):
         cpucount = int(numaspec.get("cores", 0)) * threadcount # logical cpus per numa node (cores * threads)
         diecount = int(numaspec.get("dies", 1))
         packagecount = int(numaspec.get("packages", 1))
+        cpuspresentcount = int(numaspec.get("cpus-present", 0))
         memsize = numaspec.get("mem", "0")
         memdimm = numaspec.get("dimm", "")
         if memsize != "0":
@@ -315,6 +322,10 @@ def qemuopts(numalist):
                             currentnumaparams.append("-numa node,nodeid=%s" % (lastnode,))
                         currentnumaparams[-1] = currentnumaparams[-1] + (",cpus=%s-%s" % (lastcpu + 1, lastcpu + cpucount))
                         lastcpu += cpucount
+                        if cpuspresentcount > 0:
+                            lastcpupresent += cpuspresentcount
+                        else:
+                            lastcpupresent += cpucount
                     numaparams.extend(currentnumaparams)
     node_node_dist = dists(numalist)
     for sourcenode in sorted(node_node_dist.keys()):
@@ -331,7 +342,7 @@ def qemuopts(numalist):
         # Don't give dies parameter unless it is absolutely necessary
         # because it requires Qemu >= 5.0.
         diesparam = ""
-    cpuparam = "-smp cpus=%s,threads=%s%s,sockets=%s" % (lastcpu + 1, threadcount, diesparam, lastsocket + 1)
+    smpparam = "-smp cpus=%s,threads=%s%s,sockets=%s,maxcpus=%s" % (lastcpupresent + 1, threadcount, diesparam, lastsocket + 1, lastcpu + 1)
     maxmem = siadd(totalmem, totalnvmem)
     startmem = sisub(sisub(maxmem, unpluggedmem), pluggedmem)
     memparam = "-m size=%s,slots=%s,maxmem=%s" % (startmem, memslots, maxmem)
@@ -341,6 +352,7 @@ def qemuopts(numalist):
         raise ValueError("no initial memory in any NUMA node - cannot boot with hotpluggable memory")
     return (machineparam + " " +
             cpuparam + " " +
+            smpparam + " " +
             memparam + " " +
             " ".join(numaparams) +
             " " +


### PR DESCRIPTION
Add "cpus-present" to topology for launching Qemu with only this number of CPUs plugged. The remaining ones can be hotplugged via the qmp interface, for instance. Example:

topology='[{"cores":4096,"threads":1,"mem":"16G","cpus-present":8}]' distro=debian-sid k8s=latest ./run.sh interactive qmp-shell ~/vms/data/debian-crio/qmp
(QEMU) device_add id=cpu-4095 socket-id=0 core-id=4095 thread-id=0 driver=host-x86_64-cpu ssh debian-sid "echo 1 | sudo tee /sys/devices/system/cpu/cpu4095/online"