### PR TITLE
Add new policy: demote-idle

### DIFF
--- a/cmd/memtierd/README.md
+++ b/cmd/memtierd/README.md
@@ -276,11 +276,13 @@ ssh debian@172.17.0.2 "sudo mv meme /usr/local/bin"
 
 ## Policies
 
-Memtierd implements four policies: age, heat, ratio, and
+Memtierd implements five policies: age, heat, ratio, demote-idle, and
 avoid-oom. Age and heat policies move or swap out memory based on last
 access times (age) or memory activity class (heat class). The ratio
 policy moves or swaps out a fixed ratio of least recently used
-memory. The avoid-oom policy tracks cpuset.mems from cgroups, and
+memory. The demote-idle policy demotes pages that have stayed idle
+between consecutive scans, without keeping any history of access
+counts. The avoid-oom policy tracks cpuset.mems from cgroups, and
 moves memory between nodes in case of raising risk of kernel
 out-of-memory killer.
 
@@ -384,6 +386,156 @@ memtierd> policy -create age -config {"Tracker":{"Name":"softdirty","Config":"{\
 
 The age policy works with idlepage and softdirty trackers, but not
 with the damon tracker.
+
+### The demote-idle policy
+
+The demote-idle policy is a simplified alternative to the age policy
+for one-directional memory demotion. Instead of maintaining per-page
+access counters and duration histories like the age policy does, it
+relies solely on the kernel idle page flag (`/sys/kernel/mm/page_idle/bitmap`)
+to determine whether a page has been accessed since the last scan.
+
+On every scan round the policy:
+
+1. Reads pages of interest (from PidWatcher or a PagesOfInterestDir).
+2. Checks the kernel idle page flag of each page.
+3. Sends all pages whose idle flag is still set (not accessed since
+   the previous round) to the mover for demotion.
+4. Sets the idle flag on all remaining pages of interest so that
+   access can be detected on the next round.
+
+Because demote-idle does not use any tracker or maintain access
+history, it uses significantly less memory than the age or heat
+policies. This makes it suitable for monitoring very large numbers of
+pages. The trade-off is that it only supports demotion (idle pages
+moved to slower NUMA nodes) -- not promotion of active pages. It also
+does not distinguish degrees of idleness: a page is either accessed or
+not between two consecutive scans.
+
+**Differences from the age policy:**
+
+| Feature              | age                        | demote-idle                |
+| -------------------- | -------------------------- | -------------------------- |
+| Access history       | Idle/active durations      | Single-round idle flag     |
+| Memory overhead      | Counters per region        | Minimal (no counters)      |
+| Promotion            | Yes (ActiveNumas)          | No                         |
+| Demotion             | Yes (IdleNumas)            | Yes (IdleNumas)            |
+| External POI source  | No                         | Yes (PagesOfInterestDir)   |
+
+**Kernel requirements:** `CONFIG_IDLE_PAGE_TRACKING=y`. Verify with:
+```
+[ -f /sys/kernel/mm/page_idle/bitmap ] && echo supported
+```
+
+**Note on Transparent Huge Pages (THP):** When THP is enabled, the
+idle page bitmap operates at compound page granularity (2 MB). Any
+access to a sub-page within a THP clears the idle flag for the
+entire compound page, which can cause pages to appear active when
+only a small portion is used. For accurate page-level tracking,
+disable THP before starting the tracked processes:
+```
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+```
+
+Configuration options:
+
+- `IntervalMs` (int, required): length of the scan interval in
+  milliseconds. Each round checks idle flags and demotes idle pages.
+
+- `IdleNumas` (list of ints, required): NUMA node(s) to which idle
+  pages are demoted. The first node in the list is used as the move
+  target.
+
+- `PidWatcher` (object, optional): configures which processes to
+  watch. Contains `Name` (string) and `Config` (string). Any
+  pidwatcher can be used (cgroups, proc, pidlist, filter). When a
+  PidWatcher is configured, pages of interest are read from
+  `/proc/PID/maps` of each watched process. Pages already on the
+  target IdleNumas node are filtered out before moving, and
+  successfully moved pages are removed from the pages of interest.
+  Either `PidWatcher` or `PagesOfInterestDir` (or both) must be set.
+
+- `PagesOfInterestDir` (string, optional): path to a directory
+  where an external entity writes pages-of-interest files. When set,
+  the policy reads PIDs and their virtual address ranges from this
+  directory instead of (or in addition to) scanning `/proc/PID/maps`.
+  Each file is named `<PID>.vab` (virtual addresses, binary format)
+  and contains a sequence of little-endian 64-bit address pairs:
+  `start_addr, end_addr, start_addr, end_addr, ...` where each pair
+  defines a contiguous range of pages of interest. A `lock` file in
+  the directory is used for `flock(2)`-based synchronization: the
+  external writer acquires `LOCK_EX` while updating files, and
+  memtierd acquires `LOCK_SH` (non-blocking) when reading. If the
+  exclusive lock is held, memtierd skips the scan round.
+  Either `PidWatcher` or `PagesOfInterestDir` (or both) must be set.
+
+- `Mover` (object, required): configures how pages are moved.
+  - `IntervalMs` (int): interval between `move_pages` syscalls in
+    milliseconds.
+  - `Bandwidth` (int): memory move bandwidth limit in MB/s. Use
+    high values (e.g. 10000) for fast demotion.
+
+**Example 1: PidWatcher mode (cgroups)**
+
+Demote idle pages of processes in a cgroup to NUMA nodes 2 and 3.
+Scan every 5 seconds.
+
+```
+policy:
+  name: demote-idle
+  config: |
+    intervalms: 5000
+    idlenumas: [2]
+    pidwatcher:
+      name: cgroups
+      config: |
+        intervalms: 10000
+        cgroups:
+          - /sys/fs/cgroup/workload
+    mover:
+      intervalms: 20
+      bandwidth: 2000
+```
+
+**Example 2: PagesOfInterestDir mode (external POI provider)**
+
+An external tool writes `<PID>.vab` files into `/var/run/poi`. Memtierd
+reads them and demotes idle pages to NUMA node 3. No PidWatcher is
+needed because the external provider specifies the PIDs and address
+ranges. Scan every 4 seconds with high mover bandwidth.
+
+```
+policy:
+  name: demote-idle
+  config: |
+    intervalms: 4000
+    idlenumas: [3]
+    pagesofinterestdir: /var/run/poi
+    mover:
+      intervalms: 20
+      bandwidth: 10000
+```
+
+**External POI provider locking protocol:**
+
+The external writer must follow this protocol when updating files in
+the PagesOfInterestDir:
+
+```bash
+# Acquire exclusive lock (blocks memtierd from reading)
+flock -o -x /var/run/poi/lock -c '
+    # Write or update .vab files while lock is held
+    python3 -c "
+import struct
+with open(\"/var/run/poi/12345.vab\", \"wb\") as f:
+    # Each range: (start_addr, end_addr) as little-endian uint64
+    f.write(struct.pack(\"<QQ\", 0x7f0000000000, 0x7f0000100000))
+"
+'
+# Lock is released when the flock command exits.
+# Use -o (--close) to prevent child processes from inheriting
+# the lock file descriptor.
+```
 
 ### The heat policy
 

--- a/pkg/memtier/policy_demoteidle.go
+++ b/pkg/memtier/policy_demoteidle.go
@@ -15,10 +15,16 @@
 package memtier
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -39,6 +45,15 @@ type PolicyDemoteIdleConfig struct {
 	// IdleNumas is the list of NUMA nodes where idle pages should
 	// be moved to.
 	IdleNumas []int
+	// PagesOfInterestDir is an optional directory path. When set,
+	// PIDs and their pages of interest are read from binary .vab
+	// (vab stands for Virtual Addresses, Binary format)
+	// files in this directory instead of (or in addition to) the
+	// PidWatcher/procMaps approach. Each file is named <PID>.vab
+	// and contains a sequence of little-endian (start, end) uint64
+	// address pairs. A "lock" file in the directory is used for
+	// flock(2)-based reader/writer synchronization.
+	PagesOfInterestDir string
 }
 
 // PolicyDemoteIdle implements the Policy interface.
@@ -82,20 +97,33 @@ func (p *PolicyDemoteIdle) SetConfig(config *PolicyDemoteIdleConfig) error {
 	if len(config.IdleNumas) == 0 {
 		return fmt.Errorf("demote-idle policy requires at least one IdleNumas entry")
 	}
-	if config.PidWatcher.Name == "" {
-		return fmt.Errorf("pidwatcher name missing from the demote-idle policy configuration")
+	if config.PidWatcher.Name == "" && config.PagesOfInterestDir == "" {
+		return fmt.Errorf("demote-idle policy requires pidwatcher or pagesofinterestdir")
 	}
-	newPidWatcher, err := NewPidWatcher(config.PidWatcher.Name)
-	if err != nil {
-		return err
+	if config.PagesOfInterestDir != "" {
+		info, err := os.Stat(config.PagesOfInterestDir)
+		if err != nil {
+			return fmt.Errorf("pagesofinterestdir %q: %w", config.PagesOfInterestDir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("pagesofinterestdir %q is not a directory", config.PagesOfInterestDir)
+		}
 	}
-	if err = newPidWatcher.SetConfigJSON(config.PidWatcher.Config); err != nil {
-		return fmt.Errorf("configuring pidwatcher %q for the demote-idle policy failed: %w", config.PidWatcher.Name, err)
+	if config.PidWatcher.Name != "" {
+		newPidWatcher, err := NewPidWatcher(config.PidWatcher.Name)
+		if err != nil {
+			return err
+		}
+		if err = newPidWatcher.SetConfigJSON(config.PidWatcher.Config); err != nil {
+			return fmt.Errorf("configuring pidwatcher %q for the demote-idle policy failed: %w", config.PidWatcher.Name, err)
+		}
+		p.pidwatcher = newPidWatcher
+	} else {
+		p.pidwatcher = nil
 	}
-	if err = p.mover.SetConfig(&config.Mover); err != nil {
+	if err := p.mover.SetConfig(&config.Mover); err != nil {
 		return fmt.Errorf("configuring mover failed: %s", err)
 	}
-	p.pidwatcher = newPidWatcher
 	p.config = config
 	return nil
 }
@@ -195,12 +223,14 @@ func (p *PolicyDemoteIdle) Start() error {
 	if p.config == nil {
 		return fmt.Errorf("unconfigured policy")
 	}
-	if p.pidwatcher == nil {
-		return fmt.Errorf("missing pidwatcher")
+	if p.pidwatcher == nil && p.config.PagesOfInterestDir == "" {
+		return fmt.Errorf("missing pidwatcher and pagesofinterestdir")
 	}
-	p.pidwatcher.SetPidListener(p)
-	if err := p.pidwatcher.Start(); err != nil {
-		return fmt.Errorf("pidwatcher start error: %w", err)
+	if p.pidwatcher != nil {
+		p.pidwatcher.SetPidListener(p)
+		if err := p.pidwatcher.Start(); err != nil {
+			return fmt.Errorf("pidwatcher start error: %w", err)
+		}
 	}
 	if err := p.mover.Start(); err != nil {
 		return fmt.Errorf("mover start error: %w", err)
@@ -245,17 +275,33 @@ func (p *PolicyDemoteIdle) loop() {
 }
 
 func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
-	p.mutex.Lock()
-	// Take a snapshot of pids and their ranges under lock.
+	usePOIDir := p.config.PagesOfInterestDir != ""
+
 	type pidSnapshot struct {
 		pid    int
 		ranges []pageRange
 	}
-	snapshots := make([]pidSnapshot, 0, len(p.poi))
-	for pid, ranges := range p.poi {
-		snapshots = append(snapshots, pidSnapshot{pid, ranges})
+	var snapshots []pidSnapshot
+
+	if usePOIDir {
+		poiMap, err := p.readPOIDir()
+		if err != nil {
+			log.Debugf("PolicyDemoteIdle: readPOIDir error: %s\n", err)
+			return
+		}
+		snapshots = make([]pidSnapshot, 0, len(poiMap))
+		for pid, ranges := range poiMap {
+			snapshots = append(snapshots, pidSnapshot{pid, ranges})
+		}
+		log.Debugf("PolicyDemoteIdle: readPOIDir: %d pids\n", len(snapshots))
+	} else {
+		p.mutex.Lock()
+		snapshots = make([]pidSnapshot, 0, len(p.poi))
+		for pid, ranges := range p.poi {
+			snapshots = append(snapshots, pidSnapshot{pid, ranges})
+		}
+		p.mutex.Unlock()
 	}
-	p.mutex.Unlock()
 
 	bmFile, err := ProcPageIdleBitmapOpen()
 	if err != nil {
@@ -276,9 +322,11 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 		pmFile, err := ProcPagemapOpen(pid)
 		if err != nil {
 			log.Debugf("PolicyDemoteIdle: pid %d: cannot open pagemap: %s\n", pid, err)
-			p.mutex.Lock()
-			delete(p.poi, pid)
-			p.mutex.Unlock()
+			if !usePOIDir {
+				p.mutex.Lock()
+				delete(p.poi, pid)
+				p.mutex.Unlock()
+			}
 			continue
 		}
 
@@ -299,33 +347,45 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 		})
 		if err != nil {
 			log.Debugf("PolicyDemoteIdle: pid %d: ForEachPage scan error: %s\n", pid, err)
-			p.mutex.Lock()
-			delete(p.poi, pid)
-			p.mutex.Unlock()
+			if !usePOIDir {
+				p.mutex.Lock()
+				delete(p.poi, pid)
+				p.mutex.Unlock()
+			}
 			pmFile.Close()
 			continue
 		}
+		log.Debugf("PolicyDemoteIdle: pid %d: scanned %d ranges, found %d idle pages\n",
+			pid, len(ranges), len(idlePages))
 
-		// Demote idle pages not already on the target node.
+		// Demote idle pages.
 		if len(idlePages) > 0 && p.mover.TaskCount() == 0 {
 			pp := &Pages{pid: pid, pages: idlePages}
-			ppFiltered := pp.NotOnNode(destNode)
-			if ppFiltered != nil && len(ppFiltered.Pages()) > 0 {
-				task := NewMoverTask(ppFiltered, destNode)
+			if usePOIDir {
+				// POI dir mode: trust external source, move all idle pages.
+				task := NewMoverTask(pp, destNode)
 				p.mover.AddTask(task)
-				// Subtract moved pages from pages of interest.
-				movedRanges := pagesToPageRanges(ppFiltered)
-				p.mutex.Lock()
-				if current, ok := p.poi[pid]; ok {
-					p.poi[pid] = subtractSorted(current, movedRanges)
-				}
-				p.mutex.Unlock()
 				log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
-					pid, len(ppFiltered.Pages()), destNode)
+					pid, len(idlePages), destNode)
+			} else {
+				// PidWatcher mode: filter out pages already on target.
+				ppFiltered := pp.NotOnNode(destNode)
+				if ppFiltered != nil && len(ppFiltered.Pages()) > 0 {
+					task := NewMoverTask(ppFiltered, destNode)
+					p.mover.AddTask(task)
+					movedRanges := pagesToPageRanges(ppFiltered)
+					p.mutex.Lock()
+					if current, ok := p.poi[pid]; ok {
+						p.poi[pid] = subtractSorted(current, movedRanges)
+					}
+					p.mutex.Unlock()
+					log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
+						pid, len(ppFiltered.Pages()), destNode)
+				}
 			}
 		}
 
-		// Set idle bits on all remaining pages of interest so we can
+		// Set idle bits on all pages of interest so we can
 		// detect access on the next round.
 		alreadyIdle := map[uint64]struct{}{}
 		err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
@@ -339,13 +399,85 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 			}
 			return 0
 		})
-		if err != nil {
+		if err != nil && !usePOIDir {
 			p.mutex.Lock()
 			delete(p.poi, pid)
 			p.mutex.Unlock()
 		}
 		pmFile.Close()
 	}
+}
+
+// readPOIDir reads pages of interest from .vab files in the configured
+// directory. Each file is named <PID>.vab and contains a sequence of
+// little-endian (start_addr, end_addr) uint64 pairs. A shared flock
+// on the "lock" file in the directory synchronizes with external writers.
+func (p *PolicyDemoteIdle) readPOIDir() (map[int][]pageRange, error) {
+	dir := p.config.PagesOfInterestDir
+	lockPath := filepath.Join(dir, "lock")
+	lockFile, err := os.OpenFile(lockPath, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("open lockfile %q: %w", lockPath, err)
+	}
+	defer lockFile.Close()
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_SH|syscall.LOCK_NB); err != nil {
+		if err == syscall.EWOULDBLOCK {
+			log.Debugf("PolicyDemoteIdle: readPOIDir: lock busy, skipping round\n")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("flock LOCK_SH %q: %w", lockPath, err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("readdir %q: %w", dir, err)
+	}
+
+	result := make(map[int][]pageRange)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".vab") {
+			continue
+		}
+		pidStr := strings.TrimSuffix(name, ".vab")
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+
+		buf, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			log.Debugf("PolicyDemoteIdle: readPOIDir: read %s: %s\n", name, err)
+			continue
+		}
+		if len(buf)%16 != 0 {
+			log.Debugf("PolicyDemoteIdle: readPOIDir: %s: size %d not multiple of 16\n", name, len(buf))
+			continue
+		}
+
+		ranges := make([]pageRange, 0, len(buf)/16)
+		for i := 0; i+16 <= len(buf); i += 16 {
+			start := binary.LittleEndian.Uint64(buf[i:])
+			end := binary.LittleEndian.Uint64(buf[i+8:])
+			if end <= start {
+				continue
+			}
+			ranges = append(ranges, pageRange{
+				addr:   start,
+				length: (end - start) / constUPagesize,
+			})
+		}
+		sort.Slice(ranges, func(i, j int) bool {
+			return ranges[i].addr < ranges[j].addr
+		})
+		merged := mergePageRanges(ranges)
+		if len(merged) > 0 {
+			result[pid] = merged
+		}
+	}
+	return result, nil
 }
 
 // pageRangesToAddrRanges converts internal pageRange slice to []AddrRange

--- a/pkg/memtier/policy_demoteidle.go
+++ b/pkg/memtier/policy_demoteidle.go
@@ -352,8 +352,16 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 			// physical pages at once; combining GetIdle and
 			// SetIdleAll in one pass would corrupt idle state
 			// for pages sharing the same 64-PFN bitmap word.
+			//
+			// Clear the readahead cache before scanning so
+			// GetIdle reads fresh data (SetIdleAll writes from
+			// the previous round are not reflected in the cache).
+			bmFile.SetReadahead(8)
 			idlePages := []Page{}
+			scanStartTime := time.Now().UnixNano()
+			var totScanned uint64
 			err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
+				totScanned++
 				pfn := pagemapBits & PM_PFN
 				pageIdle, err := bmFile.GetIdle(pfn)
 				if err != nil {
@@ -364,6 +372,7 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 				}
 				return 0
 			})
+			scanEndTime := time.Now().UnixNano()
 			if err != nil {
 				log.Debugf("PolicyDemoteIdle: pid %d: ForEachPage scan error: %s\n", pid, err)
 				if !usePOIDir {
@@ -374,6 +383,13 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 				pmFile.Close()
 				continue
 			}
+			stats.Store(StatsPageScan{
+				pid:      pid,
+				scanned:  totScanned,
+				accessed: totScanned - uint64(len(idlePages)),
+				written:  0,
+				timeUs:   (scanEndTime - scanStartTime) / int64(time.Microsecond),
+			})
 			log.Debugf("PolicyDemoteIdle: pid %d: scanned %d ranges, found %d idle pages\n",
 				pid, len(ranges), len(idlePages))
 

--- a/pkg/memtier/policy_demoteidle.go
+++ b/pkg/memtier/policy_demoteidle.go
@@ -312,6 +312,15 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 
 	pmAttrs := uint64(PMPresentSet | PMExclusiveSet)
 
+	// Decide early if the mover can accept new tasks.
+	// If still busy from a previous scan/demote round, skip the expensive idle
+	// page scan and only set idle bits for the next round.
+	// If mover becomes free during the round, keep adding new tasks to it.
+	moverBusyFromOldTasks := p.mover.TaskCount() > 0
+	if moverBusyFromOldTasks {
+		log.Debugf("PolicyDemoteIdle: mover busy, setting idle bits only until mover is freed\n")
+	}
+
 	for _, snap := range snapshots {
 		pid := snap.pid
 		ranges := snap.ranges
@@ -330,57 +339,72 @@ func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
 			continue
 		}
 
-		// Collect idle page addresses for this pid.
-		idlePages := []Page{}
-
 		addrRanges := pageRangesToAddrRanges(ranges)
-		err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
-			pfn := pagemapBits & PM_PFN
-			pageIdle, err := bmFile.GetIdle(pfn)
-			if err != nil {
-				return 0
-			}
-			if pageIdle {
-				idlePages = append(idlePages, Page{addr: pageAddr})
-			}
-			return 0
-		})
-		if err != nil {
-			log.Debugf("PolicyDemoteIdle: pid %d: ForEachPage scan error: %s\n", pid, err)
-			if !usePOIDir {
-				p.mutex.Lock()
-				delete(p.poi, pid)
-				p.mutex.Unlock()
-			}
-			pmFile.Close()
-			continue
-		}
-		log.Debugf("PolicyDemoteIdle: pid %d: scanned %d ranges, found %d idle pages\n",
-			pid, len(ranges), len(idlePages))
 
-		// Demote idle pages.
-		if len(idlePages) > 0 && p.mover.TaskCount() == 0 {
-			pp := &Pages{pid: pid, pages: idlePages}
-			if usePOIDir {
-				// POI dir mode: trust external source, move all idle pages.
-				task := NewMoverTask(pp, destNode)
-				p.mover.AddTask(task)
-				log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
-					pid, len(idlePages), destNode)
-			} else {
-				// PidWatcher mode: filter out pages already on target.
-				ppFiltered := pp.NotOnNode(destNode)
-				if ppFiltered != nil && len(ppFiltered.Pages()) > 0 {
-					task := NewMoverTask(ppFiltered, destNode)
-					p.mover.AddTask(task)
-					movedRanges := pagesToPageRanges(ppFiltered)
+		if moverBusyFromOldTasks {
+			moverBusyFromOldTasks = p.mover.TaskCount() > 0
+			log.Debugf("PolicyDemoteIdle: mover no more busy from old tasks, start adding new\n")
+		}
+
+		if !moverBusyFromOldTasks {
+			// Scan for idle pages. Two separate ForEachPage
+			// passes are required because SetIdleAll marks 64
+			// physical pages at once; combining GetIdle and
+			// SetIdleAll in one pass would corrupt idle state
+			// for pages sharing the same 64-PFN bitmap word.
+			idlePages := []Page{}
+			err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
+				pfn := pagemapBits & PM_PFN
+				pageIdle, err := bmFile.GetIdle(pfn)
+				if err != nil {
+					return 0
+				}
+				if pageIdle {
+					idlePages = append(idlePages, Page{addr: pageAddr})
+				}
+				return 0
+			})
+			if err != nil {
+				log.Debugf("PolicyDemoteIdle: pid %d: ForEachPage scan error: %s\n", pid, err)
+				if !usePOIDir {
 					p.mutex.Lock()
-					if current, ok := p.poi[pid]; ok {
-						p.poi[pid] = subtractSorted(current, movedRanges)
-					}
+					delete(p.poi, pid)
 					p.mutex.Unlock()
+				}
+				pmFile.Close()
+				continue
+			}
+			log.Debugf("PolicyDemoteIdle: pid %d: scanned %d ranges, found %d idle pages\n",
+				pid, len(ranges), len(idlePages))
+
+			// Submit task immediately so the mover can work
+			// in parallel while we process the next PID.
+			if len(idlePages) > 0 {
+				pp := &Pages{pid: pid, pages: idlePages}
+				if usePOIDir {
+					task := NewMoverTask(pp, destNode)
+					p.mover.AddTask(task)
 					log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
-						pid, len(ppFiltered.Pages()), destNode)
+						pid, len(idlePages), destNode)
+				} else {
+					// Note: this filtering is very expensive: every page is queried
+					// with move_pages() syscall. The other alternative would be
+					// to just submit all idle pages to the mover, but then
+					// the mover may use significant part of the bandwidth on
+					// pages that are already on the destination NUMA node.
+					ppFiltered := pp.NotOnNode(destNode)
+					if ppFiltered != nil && len(ppFiltered.Pages()) > 0 {
+						task := NewMoverTask(ppFiltered, destNode)
+						p.mover.AddTask(task)
+						movedRanges := pagesToPageRanges(ppFiltered)
+						p.mutex.Lock()
+						if current, ok := p.poi[pid]; ok {
+							p.poi[pid] = subtractSorted(current, movedRanges)
+						}
+						p.mutex.Unlock()
+						log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
+							pid, len(ppFiltered.Pages()), destNode)
+					}
 				}
 			}
 		}

--- a/pkg/memtier/policy_demoteidle.go
+++ b/pkg/memtier/policy_demoteidle.go
@@ -1,0 +1,441 @@
+// Copyright 2021 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memtier
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// pageRange is a compact representation of a contiguous page range.
+// 16 bytes per range: page-aligned virtual start address + page count.
+type pageRange struct {
+	addr   uint64 // page-aligned virtual start address
+	length uint64 // number of contiguous pages
+}
+
+// PolicyDemoteIdleConfig holds the configuration for the demote-idle policy.
+type PolicyDemoteIdleConfig struct {
+	PidWatcher PidWatcherConfig
+	Mover      MoverConfig
+	// IntervalMs is the length of the period in milliseconds
+	// between idle page scan rounds.
+	IntervalMs int
+	// IdleNumas is the list of NUMA nodes where idle pages should
+	// be moved to.
+	IdleNumas []int
+}
+
+// PolicyDemoteIdle implements the Policy interface.
+// It demotes pages that have not been accessed (kernel idle page flag
+// still set) since the previous scan round.
+type PolicyDemoteIdle struct {
+	config     *PolicyDemoteIdleConfig
+	pidwatcher PidWatcher
+	mover      *Mover
+	mutex      sync.Mutex
+	stop       chan struct{}
+	poi        map[int][]pageRange // pages of interest per pid
+}
+
+func init() {
+	PolicyRegister("demote-idle", NewPolicyDemoteIdle)
+}
+
+// NewPolicyDemoteIdle creates a new instance of the demote-idle policy.
+func NewPolicyDemoteIdle() (Policy, error) {
+	return &PolicyDemoteIdle{
+		mover: NewMover(),
+		poi:   make(map[int][]pageRange),
+	}, nil
+}
+
+// SetConfigJSON sets the policy configuration from a JSON string.
+func (p *PolicyDemoteIdle) SetConfigJSON(configJSON string) error {
+	config := &PolicyDemoteIdleConfig{}
+	if err := unmarshal(configJSON, config); err != nil {
+		return err
+	}
+	return p.SetConfig(config)
+}
+
+// SetConfig validates and applies the configuration.
+func (p *PolicyDemoteIdle) SetConfig(config *PolicyDemoteIdleConfig) error {
+	if config.IntervalMs <= 0 {
+		return fmt.Errorf("invalid demote-idle policy IntervalMs: %d, > 0 expected", config.IntervalMs)
+	}
+	if len(config.IdleNumas) == 0 {
+		return fmt.Errorf("demote-idle policy requires at least one IdleNumas entry")
+	}
+	if config.PidWatcher.Name == "" {
+		return fmt.Errorf("pidwatcher name missing from the demote-idle policy configuration")
+	}
+	newPidWatcher, err := NewPidWatcher(config.PidWatcher.Name)
+	if err != nil {
+		return err
+	}
+	if err = newPidWatcher.SetConfigJSON(config.PidWatcher.Config); err != nil {
+		return fmt.Errorf("configuring pidwatcher %q for the demote-idle policy failed: %w", config.PidWatcher.Name, err)
+	}
+	if err = p.mover.SetConfig(&config.Mover); err != nil {
+		return fmt.Errorf("configuring mover failed: %s", err)
+	}
+	p.pidwatcher = newPidWatcher
+	p.config = config
+	return nil
+}
+
+// GetConfigJSON returns the current configuration as a JSON string.
+func (p *PolicyDemoteIdle) GetConfigJSON() string {
+	if p.config == nil {
+		return ""
+	}
+	if configStr, err := json.Marshal(p.config); err == nil {
+		return string(configStr)
+	}
+	return ""
+}
+
+// PidWatcher returns the associated PidWatcher.
+func (p *PolicyDemoteIdle) PidWatcher() PidWatcher {
+	return p.pidwatcher
+}
+
+// Mover returns the associated Mover.
+func (p *PolicyDemoteIdle) Mover() *Mover {
+	return p.mover
+}
+
+// Tracker returns nil; this policy has a built-in tracker.
+func (p *PolicyDemoteIdle) Tracker() Tracker {
+	return nil
+}
+
+// AddPids adds processes to track. Reads their address ranges from
+// /proc/PID/maps and stores them as pages of interest.
+func (p *PolicyDemoteIdle) AddPids(pids []int) {
+	log.Debugf("PolicyDemoteIdle: AddPids(%v)\n", pids)
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	for _, pid := range pids {
+		ar, err := procMaps(pid)
+		if err != nil {
+			log.Debugf("PolicyDemoteIdle: failed to read maps for pid %d: %s\n", pid, err)
+			continue
+		}
+		ranges := make([]pageRange, len(ar))
+		for i, r := range ar {
+			ranges[i] = pageRange{addr: r.addr, length: r.length}
+		}
+		sort.Slice(ranges, func(i, j int) bool {
+			return ranges[i].addr < ranges[j].addr
+		})
+		merged := mergePageRanges(ranges)
+		var totalPages uint64
+		for _, r := range merged {
+			totalPages += r.length
+		}
+		p.poi[pid] = merged
+		log.Debugf("PolicyDemoteIdle: pid %d: %d ranges, %d pages (%.1f MiB)\n",
+			pid, len(merged), totalPages, float64(totalPages)*float64(constUPagesize)/float64(1024*1024))
+	}
+}
+
+// RemovePids removes processes from tracking. nil removes all.
+func (p *PolicyDemoteIdle) RemovePids(pids []int) {
+	log.Debugf("PolicyDemoteIdle: RemovePids(%v)\n", pids)
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if pids == nil {
+		p.poi = make(map[int][]pageRange)
+		return
+	}
+	for _, pid := range pids {
+		delete(p.poi, pid)
+	}
+}
+
+// Dump returns a summary of the policy state.
+func (p *PolicyDemoteIdle) Dump(args []string) string {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	totalRanges := 0
+	totalPages := uint64(0)
+	for _, ranges := range p.poi {
+		totalRanges += len(ranges)
+		for _, r := range ranges {
+			totalPages += r.length
+		}
+	}
+	return fmt.Sprintf("pids: %d, ranges: %d, pages: %d (%.1f MiB)",
+		len(p.poi), totalRanges, totalPages,
+		float64(totalPages)*float64(constUPagesize)/float64(1024*1024))
+}
+
+// Start starts the policy.
+func (p *PolicyDemoteIdle) Start() error {
+	if p.stop != nil {
+		return fmt.Errorf("already started")
+	}
+	if p.config == nil {
+		return fmt.Errorf("unconfigured policy")
+	}
+	if p.pidwatcher == nil {
+		return fmt.Errorf("missing pidwatcher")
+	}
+	p.pidwatcher.SetPidListener(p)
+	if err := p.pidwatcher.Start(); err != nil {
+		return fmt.Errorf("pidwatcher start error: %w", err)
+	}
+	if err := p.mover.Start(); err != nil {
+		return fmt.Errorf("mover start error: %w", err)
+	}
+	p.stop = make(chan struct{})
+	go p.loop()
+	return nil
+}
+
+// Stop stops the policy.
+func (p *PolicyDemoteIdle) Stop() {
+	if p.pidwatcher != nil {
+		p.pidwatcher.Stop()
+	}
+	if p.stop != nil {
+		close(p.stop)
+		p.stop = nil
+	}
+	if p.mover != nil {
+		p.mover.Stop()
+	}
+}
+
+func (p *PolicyDemoteIdle) loop() {
+	log.Debugf("PolicyDemoteIdle: online\n")
+	defer log.Debugf("PolicyDemoteIdle: offline\n")
+	ticker := time.NewTicker(time.Duration(p.config.IntervalMs) * time.Millisecond)
+	defer ticker.Stop()
+
+	destNode := Node(p.config.IdleNumas[0])
+
+	for {
+		stats.Store(StatsHeartbeat{"PolicyDemoteIdle.loop"})
+		p.scanAndDemote(destNode)
+		select {
+		case <-p.stop:
+			return
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+func (p *PolicyDemoteIdle) scanAndDemote(destNode Node) {
+	p.mutex.Lock()
+	// Take a snapshot of pids and their ranges under lock.
+	type pidSnapshot struct {
+		pid    int
+		ranges []pageRange
+	}
+	snapshots := make([]pidSnapshot, 0, len(p.poi))
+	for pid, ranges := range p.poi {
+		snapshots = append(snapshots, pidSnapshot{pid, ranges})
+	}
+	p.mutex.Unlock()
+
+	bmFile, err := ProcPageIdleBitmapOpen()
+	if err != nil {
+		log.Debugf("PolicyDemoteIdle: cannot open idle bitmap: %s\n", err)
+		return
+	}
+	defer bmFile.Close()
+
+	pmAttrs := uint64(PMPresentSet | PMExclusiveSet)
+
+	for _, snap := range snapshots {
+		pid := snap.pid
+		ranges := snap.ranges
+		if len(ranges) == 0 {
+			continue
+		}
+
+		pmFile, err := ProcPagemapOpen(pid)
+		if err != nil {
+			log.Debugf("PolicyDemoteIdle: pid %d: cannot open pagemap: %s\n", pid, err)
+			p.mutex.Lock()
+			delete(p.poi, pid)
+			p.mutex.Unlock()
+			continue
+		}
+
+		// Collect idle page addresses for this pid.
+		idlePages := []Page{}
+
+		addrRanges := pageRangesToAddrRanges(ranges)
+		err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
+			pfn := pagemapBits & PM_PFN
+			pageIdle, err := bmFile.GetIdle(pfn)
+			if err != nil {
+				return 0
+			}
+			if pageIdle {
+				idlePages = append(idlePages, Page{addr: pageAddr})
+			}
+			return 0
+		})
+		if err != nil {
+			log.Debugf("PolicyDemoteIdle: pid %d: ForEachPage scan error: %s\n", pid, err)
+			p.mutex.Lock()
+			delete(p.poi, pid)
+			p.mutex.Unlock()
+			pmFile.Close()
+			continue
+		}
+
+		// Demote idle pages not already on the target node.
+		if len(idlePages) > 0 && p.mover.TaskCount() == 0 {
+			pp := &Pages{pid: pid, pages: idlePages}
+			ppFiltered := pp.NotOnNode(destNode)
+			if ppFiltered != nil && len(ppFiltered.Pages()) > 0 {
+				task := NewMoverTask(ppFiltered, destNode)
+				p.mover.AddTask(task)
+				// Subtract moved pages from pages of interest.
+				movedRanges := pagesToPageRanges(ppFiltered)
+				p.mutex.Lock()
+				if current, ok := p.poi[pid]; ok {
+					p.poi[pid] = subtractSorted(current, movedRanges)
+				}
+				p.mutex.Unlock()
+				log.Debugf("PolicyDemoteIdle: pid %d: demoting %d idle pages to %s\n",
+					pid, len(ppFiltered.Pages()), destNode)
+			}
+		}
+
+		// Set idle bits on all remaining pages of interest so we can
+		// detect access on the next round.
+		alreadyIdle := map[uint64]struct{}{}
+		err = pmFile.ForEachPage(addrRanges, pmAttrs, func(pagemapBits uint64, pageAddr uint64) int {
+			pfn := pagemapBits & PM_PFN
+			pfnFileOffset := pfn / 64 * 8
+			if _, ok := alreadyIdle[pfnFileOffset]; !ok {
+				if err := bmFile.SetIdleAll(pfn); err != nil {
+					return -1
+				}
+				alreadyIdle[pfnFileOffset] = struct{}{}
+			}
+			return 0
+		})
+		if err != nil {
+			p.mutex.Lock()
+			delete(p.poi, pid)
+			p.mutex.Unlock()
+		}
+		pmFile.Close()
+	}
+}
+
+// pageRangesToAddrRanges converts internal pageRange slice to []AddrRange
+// for use with ForEachPage.
+func pageRangesToAddrRanges(ranges []pageRange) []AddrRange {
+	ar := make([]AddrRange, len(ranges))
+	for i, r := range ranges {
+		ar[i] = AddrRange{addr: r.addr, length: r.length}
+	}
+	return ar
+}
+
+// pagesToPageRanges converts a Pages object to sorted, merged pageRange slice.
+func pagesToPageRanges(pp *Pages) []pageRange {
+	pages := pp.Pages()
+	if len(pages) == 0 {
+		return nil
+	}
+	sort.Slice(pages, func(i, j int) bool {
+		return pages[i].addr < pages[j].addr
+	})
+	ranges := []pageRange{{addr: pages[0].addr, length: 1}}
+	for _, pg := range pages[1:] {
+		last := &ranges[len(ranges)-1]
+		if pg.addr == last.addr+last.length*constUPagesize {
+			last.length++
+		} else {
+			ranges = append(ranges, pageRange{addr: pg.addr, length: 1})
+		}
+	}
+	return ranges
+}
+
+// mergePageRanges merges overlapping or adjacent ranges in a sorted slice.
+func mergePageRanges(sorted []pageRange) []pageRange {
+	if len(sorted) == 0 {
+		return sorted
+	}
+	merged := []pageRange{sorted[0]}
+	for _, r := range sorted[1:] {
+		last := &merged[len(merged)-1]
+		lastEnd := last.addr + last.length*constUPagesize
+		if r.addr <= lastEnd {
+			rEnd := r.addr + r.length*constUPagesize
+			if rEnd > lastEnd {
+				last.length = (rEnd - last.addr) / constUPagesize
+			}
+		} else {
+			merged = append(merged, r)
+		}
+	}
+	return merged
+}
+
+// subtractSorted removes 'remove' ranges from 'from' ranges.
+// Both inputs must be sorted by addr and non-overlapping.
+// Returns a new sorted, non-overlapping slice.
+func subtractSorted(from, remove []pageRange) []pageRange {
+	result := make([]pageRange, 0, len(from))
+	ri := 0
+	for _, f := range from {
+		fStart := f.addr
+		fEnd := f.addr + f.length*constUPagesize
+		// Advance remove index past ranges that end before f starts.
+		for ri < len(remove) && remove[ri].addr+remove[ri].length*constUPagesize <= fStart {
+			ri++
+		}
+		// Process all remove ranges that overlap with f.
+		cursor := fStart
+		for j := ri; j < len(remove) && remove[j].addr < fEnd; j++ {
+			rStart := remove[j].addr
+			rEnd := remove[j].addr + remove[j].length*constUPagesize
+			if rStart > cursor {
+				// Keep the gap before this remove range.
+				result = append(result, pageRange{
+					addr:   cursor,
+					length: (rStart - cursor) / constUPagesize,
+				})
+			}
+			if rEnd > cursor {
+				cursor = rEnd
+			}
+		}
+		// Keep any remaining part after the last remove range.
+		if cursor < fEnd {
+			result = append(result, pageRange{
+				addr:   cursor,
+				length: (fEnd - cursor) / constUPagesize,
+			})
+		}
+	}
+	return result
+}

--- a/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test01-demoteidle/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test01-demoteidle/code.var.sh
@@ -45,15 +45,22 @@ policy:
       bandwidth: 10000
 "
 memtierd-start
+MEMTIERD_START_TIME=$(date +%s)
 
 sleep 4
 
 echo "waiting 700M+ (idle) to be moved to node 3"
 memtierd-match-pagemoving "3\:0\.7[0-9][0-9]" 12 8
+PHASE1_DONE_TIME=$(date +%s)
+PHASE1_ELAPSED=$(( PHASE1_DONE_TIME - MEMTIERD_START_TIME ))
+echo "TIMING: phase 1 (idle demotion) completed in ${PHASE1_ELAPSED}s"
 
 echo "stop meme, expect remaining ~300M to be moved to node 3 too"
 vm-command "kill -STOP ${MEME_PID}"
 memtierd-match-pagemoving "3\:1\.[0-2]" 8 8
+PHASE2_DONE_TIME=$(date +%s)
+PHASE2_ELAPSED=$(( PHASE2_DONE_TIME - MEMTIERD_START_TIME ))
+echo "TIMING: phase 2 (full demotion) completed in ${PHASE2_ELAPSED}s"
 
 memtierd-stop
 memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test01-demoteidle/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test01-demoteidle/code.var.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Make sure the system has IDLEPAGE support enabled
+# shellcheck disable=SC2154
+vm-command "[ -f /sys/kernel/mm/page_idle/bitmap ]" || {
+    error "idlepage support required for demote-idle policy"
+}
+
+# Disable transparent huge pages: idle page tracking operates at
+# 4K granularity; with THPs any sub-page access marks the entire
+# compound page active, causing Go GC to hide truly idle pages.
+vm-command "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+
+# Install numactl so we can migrate all meme memory to node 0
+# regardless of where Go runtime initially allocated it.
+vm-command "which migratepages >/dev/null 2>&1 || apt-get install -y -qq numactl"
+
+memtierd-setup
+
+# Test meme process which has 1G of memory and reads actively 300M.
+# ~700M idle should be demoted to node 3.
+MEME_CGROUP=e2e-meme
+MEME_BS=1G MEME_BRC=1 MEME_BRS=300M MEME_MEMS=0 memtierd-meme-start
+
+# Ensure all of meme's memory starts on node 0. memtierd-meme-start
+# sets cpuset.mems after meme has already allocated, so Go runtime
+# may have spread pages across nodes.
+vm-command "migratepages ${MEME_PID} 1,2,3 0"
+sleep 2
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: demote-idle
+  config: |
+    intervalms: 4000
+    idlenumas: [3]
+    pidwatcher:
+      name: cgroups
+      config: |
+        cgroups:
+          - /sys/fs/cgroup/${MEME_CGROUP}
+    mover:
+      intervalms: 20
+      bandwidth: 10000
+"
+memtierd-start
+
+sleep 4
+
+echo "waiting 700M+ (idle) to be moved to node 3"
+memtierd-match-pagemoving "3\:0\.7[0-9][0-9]" 12 8
+
+echo "stop meme, expect remaining ~300M to be moved to node 3 too"
+vm-command "kill -STOP ${MEME_PID}"
+memtierd-match-pagemoving "3\:1\.[0-2]" 8 8
+
+memtierd-stop
+memtierd-meme-stop

--- a/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test02-poi/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test02-poi/code.var.sh
@@ -82,6 +82,7 @@ policy:
       bandwidth: 10000
 "
 memtierd-start
+MEMTIERD_START_TIME=$(date +%s)
 
 # Verify: empty dir (no lock file) → no pages move.
 sleep 8
@@ -126,6 +127,9 @@ N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
 echo "phase 1 result: node3=${N3_MB}MB (${N3_PAGES} pages)"
 
 # Should have moved ~200M — not more (upper bound verifies range precision).
+PHASE1_DONE_TIME=$(date +%s)
+PHASE1_ELAPSED=$(( PHASE1_DONE_TIME - MEMTIERD_START_TIME ))
+echo "TIMING: phase 1 (200M idle demotion) completed in ${PHASE1_ELAPSED}s"
 if (( N3_MB < 100 )); then
     error "phase 1: expected >=100MB on node 3, got ${N3_MB}MB"
 fi
@@ -156,6 +160,9 @@ N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
 echo "phase 2 result: node3=${N3_MB}MB (${N3_PAGES} pages)"
 
 # Should have ~200M (phase 1) + ~500M (phase 2) = ~700M total on node 3.
+PHASE2_DONE_TIME=$(date +%s)
+PHASE2_ELAPSED=$(( PHASE2_DONE_TIME - MEMTIERD_START_TIME ))
+echo "TIMING: phase 2 (full idle demotion) completed in ${PHASE2_ELAPSED}s"
 if (( N3_MB < 550 )); then
     error "phase 2: expected >=550MB on node 3, got ${N3_MB}MB"
 fi

--- a/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test02-poi/code.var.sh
+++ b/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/test02-poi/code.var.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# Test demote-idle policy with PagesOfInterestDir, verifying:
+# 1. flock-based locking between external writer and memtierd
+# 2. PID.vab address range precision (only specified ranges get demoted)
+# 3. Incremental POI updates
+
+# --- Helper functions for external POI writer ---
+# These demonstrate the locking protocol for external POI generators.
+
+# poi-lock: acquire exclusive lock on the POI directory.
+# Creates the lock file if it does not exist. Holds LOCK_EX until
+# poi-unlock is called. While held, memtierd skips the scan round.
+# Uses flock -o (--close) so the child process does not inherit the
+# lock fd — otherwise killing flock leaves an orphan holding LOCK_EX.
+poi-lock() {
+    vm-command "nohup flock -o -x ${POI_DIR}/lock -c 'sleep 3600' </dev/null >/dev/null 2>&1 & echo \$!"
+    POI_LOCK_PID=${COMMAND_OUTPUT##*$'\n'}
+    sleep 1
+}
+
+# poi-unlock: release the exclusive lock by terminating the holder.
+# Verifies via fuser that the lock is actually released.
+poi-unlock() {
+    vm-command "kill ${POI_LOCK_PID} 2>/dev/null; sleep 0.5; fuser ${POI_DIR}/lock 2>/dev/null && echo 'WARNING: lock still held' || echo 'lock released ok'"
+    sleep 1
+}
+
+# --- Standard test setup ---
+
+# shellcheck disable=SC2154
+vm-command "[ -f /sys/kernel/mm/page_idle/bitmap ]" || {
+    error "idlepage support required for demote-idle policy"
+}
+
+vm-command "echo never > /sys/kernel/mm/transparent_hugepage/enabled"
+vm-command "which migratepages >/dev/null 2>&1 || apt-get install -y -qq numactl"
+
+memtierd-setup
+
+# Start meme: 1G total, actively reading 300M from offset 0.
+MEME_CGROUP=e2e-meme
+MEME_BS=1G MEME_BRC=1 MEME_BRS=300M MEME_MEMS=0 memtierd-meme-start
+
+# Move all memory to node 0.
+vm-command "migratepages ${MEME_PID} 1,2,3 0"
+sleep 2
+
+# Parse meme array address and size.
+vm-command "cat meme0.output.txt"
+ARRAY_START=$(awk '/array:/{split($2,a,"-"); print a[1]}' <<<"$COMMAND_OUTPUT")
+ARRAY_BYTES=$(awk '/array:/{gsub(/[()]/,"",$3); print $3}' <<<"$COMMAND_OUTPUT")
+echo "meme array: start=0x${ARRAY_START} bytes=${ARRAY_BYTES}"
+
+# Meme layout (BRS=300M, BRO=0):
+#   [0, 300M)   = active (being read)
+#   [300M, 1G)  = idle
+ACTIVE_BYTES=314572800
+IDLE_OFFSET=${ACTIVE_BYTES}
+# Phase 1: 200M of idle range
+PHASE1_SIZE=209715200
+# Phase 2: remaining idle range
+PHASE2_OFFSET=$(( IDLE_OFFSET + PHASE1_SIZE ))
+PHASE2_SIZE=$(( ARRAY_BYTES - PHASE2_OFFSET ))
+echo "phase 1 range: offset=${IDLE_OFFSET} size=${PHASE1_SIZE} (200M)"
+echo "phase 2 range: offset=${PHASE2_OFFSET} size=${PHASE2_SIZE}"
+
+# --- Start with EMPTY POI directory (no lock file, no .vab) ---
+POI_DIR=/tmp/poi-test02
+vm-command "rm -rf ${POI_DIR} && mkdir -p ${POI_DIR}"
+
+# shellcheck disable=SC2034
+MEMTIERD_YAML="
+policy:
+  name: demote-idle
+  config: |
+    intervalms: 4000
+    idlenumas: [3]
+    pagesofinterestdir: ${POI_DIR}
+    mover:
+      intervalms: 20
+      bandwidth: 10000
+"
+memtierd-start
+
+# Verify: empty dir (no lock file) → no pages move.
+sleep 8
+vm-command "awk '{for(i=1;i<=NF;i++){if(\$i~/^N3=/){split(\$i,a,\"=\");s+=a[2]}}} END{print s+0}' /proc/${MEME_PID}/numa_maps"
+N3_PAGES=${COMMAND_OUTPUT##*$'\n'}
+N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
+echo "empty dir check: node3=${N3_MB}MB (${N3_PAGES} pages)"
+if (( N3_MB > 20 )); then
+    error "expected no movement with empty POI dir, got ${N3_MB}MB on node 3"
+fi
+
+# --- Phase 1: lock, write small idle range (200M), unlock ---
+echo "=== Phase 1: adding 200M idle range ==="
+poi-lock
+
+# Write .vab with 200M of idle range starting after the active region.
+vm-command "python3 -c \"
+import struct
+start = 0x${ARRAY_START} + ${IDLE_OFFSET}
+end = start + ${PHASE1_SIZE}
+with open('${POI_DIR}/${MEME_PID}.vab', 'wb') as f:
+    f.write(struct.pack('<QQ', start, end))
+\""
+
+# While lock is held, memtierd cannot read → nothing should move yet.
+sleep 10
+vm-command "awk '{for(i=1;i<=NF;i++){if(\$i~/^N3=/){split(\$i,a,\"=\");s+=a[2]}}} END{print s+0}' /proc/${MEME_PID}/numa_maps"
+N3_PAGES=${COMMAND_OUTPUT##*$'\n'}
+N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
+echo "lock held check: node3=${N3_MB}MB (${N3_PAGES} pages)"
+if (( N3_MB > 20 )); then
+    error "pages moved while lock was held: ${N3_MB}MB on node 3"
+fi
+
+poi-unlock
+
+# Wait for memtierd: round 1 sets idle bits, round 2 detects + moves.
+sleep 16
+vm-command "awk '{for(i=1;i<=NF;i++){if(\$i~/^N3=/){split(\$i,a,\"=\");s+=a[2]}}} END{print s+0}' /proc/${MEME_PID}/numa_maps"
+N3_PAGES=${COMMAND_OUTPUT##*$'\n'}
+N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
+echo "phase 1 result: node3=${N3_MB}MB (${N3_PAGES} pages)"
+
+# Should have moved ~200M — not more (upper bound verifies range precision).
+if (( N3_MB < 100 )); then
+    error "phase 1: expected >=100MB on node 3, got ${N3_MB}MB"
+fi
+if (( N3_MB > 350 )); then
+    error "phase 1: range precision violated, expected <=350MB but got ${N3_MB}MB on node 3"
+fi
+
+# --- Phase 2: lock, add remaining idle range, unlock ---
+echo "=== Phase 2: adding remaining idle range ==="
+poi-lock
+
+# Rewrite .vab with the remaining idle range (not yet demoted).
+vm-command "python3 -c \"
+import struct
+start = 0x${ARRAY_START} + ${PHASE2_OFFSET}
+end = start + ${PHASE2_SIZE}
+with open('${POI_DIR}/${MEME_PID}.vab', 'wb') as f:
+    f.write(struct.pack('<QQ', start, end))
+\""
+
+poi-unlock
+
+# Wait for 2 rounds: set idle bits then check + move.
+sleep 16
+vm-command "awk '{for(i=1;i<=NF;i++){if(\$i~/^N3=/){split(\$i,a,\"=\");s+=a[2]}}} END{print s+0}' /proc/${MEME_PID}/numa_maps"
+N3_PAGES=${COMMAND_OUTPUT##*$'\n'}
+N3_MB=$(( N3_PAGES * 4096 / 1048576 ))
+echo "phase 2 result: node3=${N3_MB}MB (${N3_PAGES} pages)"
+
+# Should have ~200M (phase 1) + ~500M (phase 2) = ~700M total on node 3.
+if (( N3_MB < 550 )); then
+    error "phase 2: expected >=550MB on node 3, got ${N3_MB}MB"
+fi
+
+memtierd-stop
+memtierd-meme-stop
+vm-command "rm -rf ${POI_DIR}"

--- a/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/topology.var.json
+++ b/test/e2e/memtierd.test-suite/policy-demoteidle/n4c16/topology.var.json
@@ -1,0 +1,3 @@
+[
+    {"mem": "2G", "cores": 2, "nodes": 2, "packages": 2}
+]


### PR DESCRIPTION
The demote-idle policy is a stripped-down and optimized version of the age policy, useful for unidirectional memory movement of idle pages.
The policy supports external input of pages-of-interest from <PID>.vab files.
The policy implements its own (built-in) page tracker that triggers new page moves already during tracking.